### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/Driver/SimpleDriver.py
+++ b/Driver/SimpleDriver.py
@@ -103,7 +103,7 @@ class SimpleDriver(DefaultDriver):
   def _status(self):
     # get the return status of the process
 
-    if self._popen_status != None:
+    if self._popen_status is not None:
       return self._popen_status
 
     if self._popen:

--- a/Modules/Indexer/IndexerFactory.py
+++ b/Modules/Indexer/IndexerFactory.py
@@ -50,7 +50,7 @@ def IndexerForXSweep(xsweep, json_file=None):
 
   # check what is going on
 
-  if xsweep == None:
+  if xsweep is None:
     raise RuntimeError, 'XSweep instance needed'
 
   if not xsweep.__class__.__name__ == 'XSweep':

--- a/Modules/Indexer/MosflmIndexer.py
+++ b/Modules/Indexer/MosflmIndexer.py
@@ -198,7 +198,7 @@ class MosflmIndexer(IndexerSingleSweep):
     if self._indxr_input_cell:
       indexer.set_unit_cell(self._indxr_input_cell)
 
-    if self._indxr_input_lattice != None:
+    if self._indxr_input_lattice is not None:
       spacegroup_number = lattice_to_spacegroup(
           self._indxr_input_lattice)
       indexer.set_space_group_number(spacegroup_number)

--- a/Modules/Indexer/MosflmIntegrateAbsences.py
+++ b/Modules/Indexer/MosflmIntegrateAbsences.py
@@ -30,8 +30,8 @@ def measure(hklin, spacegroup):
         elif column.label() == 'SIGIPR':
           sigipr_column = column
 
-  assert(ipr_column != None)
-  assert(sigipr_column != None)
+  assert(ipr_column is not None)
+  assert(sigipr_column is not None)
 
   ipr_values = ipr_column.extract_values(not_a_number_substitute = 0.0)
   sigipr_values = sigipr_column.extract_values(not_a_number_substitute = 0.0)

--- a/Modules/Indexer/XDSIndexerII.py
+++ b/Modules/Indexer/XDSIndexerII.py
@@ -143,7 +143,7 @@ class XDSIndexerII(XDSIndexer):
 
     # set the phi start etc correctly
 
-    if self._i_or_ii == None:
+    if self._i_or_ii is None:
       self._i_or_ii = self.decide_i_or_ii()
       Debug.write('Selecting I or II, chose %s' % self._i_or_ii)
 

--- a/Modules/Integrater/IntegraterFactory.py
+++ b/Modules/Integrater/IntegraterFactory.py
@@ -35,7 +35,7 @@ def IntegraterForXSweep(xsweep, json_file=None):
   XSweep.'''
 
   # FIXME this needs properly implementing...
-  if xsweep == None:
+  if xsweep is None:
     raise RuntimeError, 'XSweep instance needed'
 
   if not xsweep.__class__.__name__ == 'XSweep':

--- a/Modules/Integrater/MosflmIntegrater.py
+++ b/Modules/Integrater/MosflmIntegrater.py
@@ -281,7 +281,7 @@ class MosflmIntegrater(Integrater):
 
     pname, xname, dname = self.get_integrater_project_info()
 
-    if pname != None and xname != None and dname != None:
+    if pname is not None and xname is not None and dname is not None:
       Debug.write('Harvesting: %s/%s/%s' % (pname, xname, dname))
 
       harvest_dir = os.path.join(os.environ['HARVESTHOME'],
@@ -598,7 +598,7 @@ class MosflmIntegrater(Integrater):
 
       # N.B. for harvesting need to append N to dname.
 
-      if pname != None and xname != None and dname != None:
+      if pname is not None and xname is not None and dname is not None:
         Debug.write('Harvesting: %s/%s/%s' %
                     (pname, xname, dname))
 

--- a/Modules/PyChef/PyChef.py
+++ b/Modules/PyChef/PyChef.py
@@ -215,10 +215,10 @@ class PyChef(object):
             if column.label() == 'SIGI':
               sigi_column = column
 
-      assert(base_column != None)
-      assert(misym_column != None)
-      assert(i_column != None)
-      assert(sigi_column != None)
+      assert(base_column is not None)
+      assert(misym_column is not None)
+      assert(i_column is not None)
+      assert(sigi_column is not None)
 
       if batch_column and dose_column:
 
@@ -285,13 +285,13 @@ class PyChef(object):
         if mean_shift < overall_range_width:
           overall_range_width = mean_shift
 
-      if overall_range_min == None:
+      if overall_range_min is None:
         overall_range_min = min_base
       else:
         if min_base < overall_range_min:
           overall_range_min = min_base
 
-      if overall_range_max == None:
+      if overall_range_max is None:
         overall_range_max = max_base
       else:
         if max_base > overall_range_max:
@@ -326,11 +326,11 @@ class PyChef(object):
 
         # test whether this is within the range of interest
 
-        if self._range_min != None:
+        if self._range_min is not None:
           if base < self._range_min:
             continue
 
-        if self._range_max != None:
+        if self._range_max is not None:
           if base > self._range_max:
             continue
 

--- a/Modules/Refiner/RefinerFactory.py
+++ b/Modules/Refiner/RefinerFactory.py
@@ -29,7 +29,7 @@ def RefinerForXSweep(xsweep, json_file=None):
   XSweep.'''
 
   # FIXME this needs properly implementing...
-  if xsweep == None:
+  if xsweep is None:
     raise RuntimeError, 'XSweep instance needed'
 
   if not xsweep.__class__.__name__ == 'XSweep':

--- a/Modules/Scaler/CCP4ScalerHelpers.py
+++ b/Modules/Scaler/CCP4ScalerHelpers.py
@@ -307,7 +307,7 @@ class CCP4ScalerHelper(object):
 
         break
 
-    if correct_lattice == None:
+    if correct_lattice is None:
       correct_lattice = refiner.get_refiner_lattice()
       rerun_pointless = True
 

--- a/Modules/Scaler/XDSScalerA.py
+++ b/Modules/Scaler/XDSScalerA.py
@@ -211,7 +211,7 @@ class XDSScalerA(Scaler):
 
         break
 
-    if correct_lattice == None:
+    if correct_lattice is None:
       correct_lattice = refiner.get_refiner_lattice()
       rerun_pointless = True
 
@@ -1110,7 +1110,7 @@ class XDSScalerA(Scaler):
               'prepared_reflections'])[-1] == \
               os.path.split(hklout)[-1]:
             if self._sweep_information[epoch][
-                'scaled_reflections'] != None:
+                'scaled_reflections'] is not None:
               raise RuntimeError, 'duplicate entries'
             self._sweep_information[epoch][
                 'scaled_reflections'] = ref[hklout]

--- a/Modules/Xia2html/Canary.py
+++ b/Modules/Xia2html/Canary.py
@@ -196,7 +196,7 @@ class Section(DocElement):
     etc)."""
     # Specific class properties
     self.__title = None
-    if title != None: self.__title = str(title)
+    if title is not None: self.__title = str(title)
     self.__subsections = []
     self.__content = []
     self.__level = level
@@ -219,7 +219,7 @@ class Section(DocElement):
     # Base part of the id is a unique id from the parent
     id = "sect_"+str(self.getDocId())
     # Add some title text to make it more human-friendly
-    if self.__title != None:
+    if self.__title is not None:
       id += "-"+replace_special_characters(self.__title)
     return id
 
@@ -848,7 +848,7 @@ class Table(DocElement):
           item_str = item.render()
         except AttributeError:
           # Assume item has no render method
-          if item == None:
+          if item is None:
             item_str = ''
           else:
             item_str = str(item)

--- a/Modules/Xia2html/baubles.py
+++ b/Modules/Xia2html/baubles.py
@@ -1162,7 +1162,7 @@ def summariseGeneric(html,program):
       warnings.append( str(keytext.message() ) )
     elif keytext.name() == "Result":
       result = str(keytext.message())
-  if result != None:
+  if result is not None:
     html.write("<div class=\"keytext\">\n")
     html.write("<p><b>Result:</b><div class=result>\n")
     html.write(plainTextMarkup(result))

--- a/Schema/XSweep.py
+++ b/Schema/XSweep.py
@@ -261,7 +261,7 @@ class XSweep(object):
 
       beam_ = self._imageset.get_beam()
       scan = self._imageset.get_scan()
-      if not wavelength == None:
+      if not wavelength is None:
 
         # FIXME 29/NOV/06 if the wavelength wavelength value
         # is 0.0 then first set it to the header value - note
@@ -619,7 +619,7 @@ class XSweep(object):
     '''Get my indexer, if set, else create a new one from the
     factory.'''
 
-    if self._indexer == None:
+    if self._indexer is None:
       # set the working directory for this, based on the hierarchy
       # defined herein...
 
@@ -681,7 +681,7 @@ class XSweep(object):
 
   def _get_refiner(self):
 
-    if self._refiner == None:
+    if self._refiner is None:
       # set the working directory for this, based on the hierarchy
       # defined herein...
 
@@ -750,7 +750,7 @@ class XSweep(object):
   def _get_integrater(self):
     '''Get my integrater, and if it is not set, create one.'''
 
-    if self._integrater == None:
+    if self._integrater is None:
 
       # set the working directory for this, based on the hierarchy
       # defined herein...

--- a/Test/Mosflm/Original.py
+++ b/Test/Mosflm/Original.py
@@ -322,7 +322,7 @@ def Mosflm(DriverType = None):
         self.input('cell %f %f %f %f %f %f' % \
                    self._indxr_input_cell)
 
-      if self._indxr_input_lattice != None:
+      if self._indxr_input_lattice is not None:
         spacegroup_number = lattice_to_spacegroup(
             self._indxr_input_lattice)
         self.input('symmetry %d' % spacegroup_number)
@@ -1743,7 +1743,7 @@ def Mosflm(DriverType = None):
 
       pname, xname, dname = self.get_integrater_project_info()
 
-      if pname != None and xname != None and dname != None:
+      if pname is not None and xname is not None and dname is not None:
         Debug.write('Harvesting: %s/%s/%s' % (pname, xname, dname))
 
         harvest_dir = os.path.join(os.environ['HARVESTHOME'],
@@ -2276,7 +2276,7 @@ def Mosflm(DriverType = None):
 
         # N.B. for harvesting need to append N to dname.
 
-        if pname != None and xname != None and dname != None:
+        if pname is not None and xname is not None and dname is not None:
           Debug.write('Harvesting: %s/%s/%s' %
                       (pname, xname, dname))
 

--- a/Wrappers/CCP4/Aimless.py
+++ b/Wrappers/CCP4/Aimless.py
@@ -120,7 +120,7 @@ def Aimless(DriverType = None,
       # these are only relevant for 'rotation' mode scaling
       self._spacing = 5
 
-      if absorption_correction == None:
+      if absorption_correction is None:
         self._secondary = Flags.get_aimless_secondary()
       elif absorption_correction == True:
         self._secondary = Flags.get_aimless_secondary()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:xia2:xia2?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:xia2:xia2?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)