### PR TITLE
Dials 1.2.5

### DIFF
--- a/Modules/UnitCellErrors.py
+++ b/Modules/UnitCellErrors.py
@@ -17,7 +17,6 @@ class _refinery:
     self.constraints, self.restraints, self.side_restraints = {}, {}, {}
     if lattice == 'm':
       self.constraints = { 3:90, 5:90 } # alpha, gamma = 90
-      self.restraints = { 4:90 } # beta >= 90
 
     elif lattice == 'o':
       self.constraints = { 3:90, 4:90, 5:90 }

--- a/Schema/XProject.py
+++ b/Schema/XProject.py
@@ -217,6 +217,9 @@ class XProject(object):
         xsample = XSample(sample, xc)
         xc.add_sample(xsample)
 
+      if not crystals[crystal]['wavelengths']:
+        raise RuntimeError('No wavelengths specified in xinfo file')
+
       for wavelength in crystals[crystal]['wavelengths'].keys():
         # FIXME 29/NOV/06 in here need to be able to cope with
         # no wavelength information - this should default to the


### PR DESCRIPTION
xia2:
- catch missing wavelength in xinfo file
- relax erroneous constraint for unit cell error estimates