### PR TITLE
pickle to msgpack changes

### DIFF
--- a/Modules/Indexer/XDSIndexer.py
+++ b/Modules/Indexer/XDSIndexer.py
@@ -470,8 +470,8 @@ class XDSIndexer(IndexerSingleSweep):
             spotfinder.run()
             export = self.DialsExportSpotXDS()
             export.set_input_data_file(
-                "reflections.pickle",
-                spotfinder.get_output_data_file("reflections.pickle"),
+                "reflections.mpack",
+                spotfinder.get_output_data_file("reflections.mpack"),
             )
             export.run()
 

--- a/Modules/Indexer/XDSIndexerII.py
+++ b/Modules/Indexer/XDSIndexerII.py
@@ -102,11 +102,11 @@ class XDSIndexerII(XDSIndexer):
         from dials.array_family import flex
         from dials.util.ascii_art import spot_counts_per_image_plot
 
-        reflection_pickle = spot_xds_to_reflection_pickle(
+        reflections_file = spot_xds_to_reflection_file(
             self._indxr_payload["SPOT.XDS"],
             working_directory=self.get_working_directory(),
         )
-        refl = flex.reflection_table.from_pickle(reflection_pickle)
+        refl = flex.reflection_table.from_file(reflections_file)
         Chatter.write(spot_counts_per_image_plot(refl), strip=False)
 
     def _index(self):
@@ -422,7 +422,7 @@ class XDSIndexerII(XDSIndexer):
         return idxref.get_fraction_rmsd_rmsphi()
 
 
-def spot_xds_to_reflection_pickle(spot_xds, working_directory):
+def spot_xds_to_reflection_file(spot_xds, working_directory):
     from xia2.Wrappers.Dials.ImportXDS import ImportXDS
 
     importer = ImportXDS()

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -47,7 +47,7 @@ class DialsIntegrater(Integrater):
         self._integrate_parameters = {}
         self._intgr_integrated_filename = None
 
-        self._intgr_integrated_pickle = None
+        self._intgr_integrated_filename = None
         self._intgr_experiments_filename = None
 
     # overload these methods as we don't want the resolution range
@@ -74,7 +74,7 @@ class DialsIntegrater(Integrater):
         return self._intgr_integrated_filename
 
     def get_integrated_reflections(self):
-        return self._intgr_integrated_pickle
+        return self._intgr_integrated_filename
 
     def set_integrated_experiments(self, filename):
         Integrater.set_integrated_experiments = filename
@@ -114,7 +114,7 @@ class DialsIntegrater(Integrater):
         report = _Report()
         report.set_working_directory(self.get_working_directory())
         report.set_experiments_filename(self._intgr_experiments_filename)
-        report.set_reflections_filename(self._intgr_integrated_pickle)
+        report.set_reflections_filename(self._intgr_integrated_filename)
         auto_logfiler(report, "REPORT")
         return report
 
@@ -236,7 +236,7 @@ class DialsIntegrater(Integrater):
         )
         experiments = load.experiment_list(self._intgr_experiments_filename)
         experiment = experiments[0]
-        self._intgr_indexed_filename = refiner.get_refiner_payload("reflections.pickle")
+        self._intgr_indexed_filename = refiner.get_refiner_payload("reflections.mpack")
 
         # this is the result of the cell refinement
         self._intgr_cell = experiment.crystal.get_unit_cell().parameters()
@@ -346,7 +346,7 @@ class DialsIntegrater(Integrater):
                 integrate.set_reflections_per_degree(1000)
                 integrate.run()
 
-                integrated_pickle = integrate.get_integrated_filename()
+                integrated_filename = integrate.get_integrated_filename()
 
                 from xia2.Wrappers.Dials.EstimateResolutionLimit import (
                     EstimateResolutionLimit,
@@ -358,7 +358,7 @@ class DialsIntegrater(Integrater):
                 d_min_estimater.set_experiments_filename(
                     self._intgr_experiments_filename
                 )
-                d_min_estimater.set_reflections_filename(integrated_pickle)
+                d_min_estimater.set_reflections_filename(integrated_filename)
                 d_min = d_min_estimater.run()
 
                 Debug.write("Estimate for d_min: %.2f" % d_min)
@@ -380,10 +380,10 @@ class DialsIntegrater(Integrater):
         # integration log on the quality of the data and (iii) the mosaic spread
         # range observed and R.M.S. deviations.
 
-        self._intgr_integrated_pickle = integrate.get_integrated_reflections()
-        if not os.path.isfile(self._intgr_integrated_pickle):
+        self._intgr_integrated_filename = integrate.get_integrated_reflections()
+        if not os.path.isfile(self._intgr_integrated_filename):
             raise RuntimeError(
-                "Integration failed: %s does not exist." % self._intgr_integrated_pickle
+                "Integration failed: %s does not exist." % self._intgr_integrated_filename
             )
 
         self._intgr_per_image_statistics = integrate.get_per_image_statistics()
@@ -413,7 +413,7 @@ class DialsIntegrater(Integrater):
             % self.get_integrater_mosaic_min_mean_max()
         )
 
-        return self._intgr_integrated_pickle
+        return self._intgr_integrated_filename
 
     def _integrate_finish(self):
         """Finish off the integration by running dials.export."""
@@ -426,7 +426,7 @@ class DialsIntegrater(Integrater):
 
         if self._output_format == "hkl":
             exporter = self.ExportMtz()
-            exporter.set_reflections_filename(self._intgr_integrated_pickle)
+            exporter.set_reflections_filename(self._intgr_integrated_filename)
             mtz_filename = os.path.join(
                 self.get_working_directory(), "%s_integrated.mtz" % "dials"
             )
@@ -531,7 +531,7 @@ class DialsIntegrater(Integrater):
 
             return hklout
 
-        elif self._output_format == "pickle":
+        elif self._output_format == "mpack":
 
             if (
                 self._intgr_reindex_operator is None
@@ -544,7 +544,7 @@ class DialsIntegrater(Integrater):
                     "Not reindexing to spacegroup %d (%s)"
                     % (self._intgr_spacegroup_number, self._intgr_reindex_operator)
                 )
-                return self._intgr_integrated_pickle
+                return self._intgr_integrated_filename
 
             if (
                 self._intgr_reindex_operator is None
@@ -554,7 +554,7 @@ class DialsIntegrater(Integrater):
                     "Not reindexing to spacegroup %d (%s)"
                     % (self._intgr_spacegroup_number, self._intgr_reindex_operator)
                 )
-                return self._intgr_integrated_pickle
+                return self._intgr_integrated_filename
 
             Debug.write(
                 "Reindexing to spacegroup %d (%s)"
@@ -581,7 +581,7 @@ class DialsIntegrater(Integrater):
             reindex.set_indexed_filename(self.get_integrated_reflections())
 
             reindex.run()
-            self._intgr_integrated_pickle = reindex.get_reindexed_reflections_filename()
+            self._intgr_integrated_filename = reindex.get_reindexed_reflections_filename()
             self._intgr_integrated_filename = (
                 reindex.get_reindexed_reflections_filename()
             )

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -47,7 +47,7 @@ class DialsIntegrater(Integrater):
         self._integrate_parameters = {}
         self._intgr_integrated_filename = None
 
-        self._intgr_integrated_filename = None
+        self._intgr_integrated_reflections = None
         self._intgr_experiments_filename = None
 
     # overload these methods as we don't want the resolution range
@@ -74,7 +74,7 @@ class DialsIntegrater(Integrater):
         return self._intgr_integrated_filename
 
     def get_integrated_reflections(self):
-        return self._intgr_integrated_filename
+        return self._intgr_integrated_reflections
 
     def set_integrated_experiments(self, filename):
         Integrater.set_integrated_experiments = filename
@@ -114,7 +114,7 @@ class DialsIntegrater(Integrater):
         report = _Report()
         report.set_working_directory(self.get_working_directory())
         report.set_experiments_filename(self._intgr_experiments_filename)
-        report.set_reflections_filename(self._intgr_integrated_filename)
+        report.set_reflections_filename(self._intgr_integrated_reflections)
         auto_logfiler(report, "REPORT")
         return report
 
@@ -346,7 +346,7 @@ class DialsIntegrater(Integrater):
                 integrate.set_reflections_per_degree(1000)
                 integrate.run()
 
-                integrated_filename = integrate.get_integrated_filename()
+                integrated_reflections = integrate.get_integrated_filename()
 
                 from xia2.Wrappers.Dials.EstimateResolutionLimit import (
                     EstimateResolutionLimit,
@@ -358,7 +358,7 @@ class DialsIntegrater(Integrater):
                 d_min_estimater.set_experiments_filename(
                     self._intgr_experiments_filename
                 )
-                d_min_estimater.set_reflections_filename(integrated_filename)
+                d_min_estimater.set_reflections_filename(integrated_reflections)
                 d_min = d_min_estimater.run()
 
                 Debug.write("Estimate for d_min: %.2f" % d_min)
@@ -380,10 +380,10 @@ class DialsIntegrater(Integrater):
         # integration log on the quality of the data and (iii) the mosaic spread
         # range observed and R.M.S. deviations.
 
-        self._intgr_integrated_filename = integrate.get_integrated_reflections()
-        if not os.path.isfile(self._intgr_integrated_filename):
+        self._intgr_integrated_reflections = integrate.get_integrated_reflections()
+        if not os.path.isfile(self._intgr_integrated_reflections):
             raise RuntimeError(
-                "Integration failed: %s does not exist." % self._intgr_integrated_filename
+                "Integration failed: %s does not exist." % self._intgr_integrated_reflections
             )
 
         self._intgr_per_image_statistics = integrate.get_per_image_statistics()
@@ -400,7 +400,6 @@ class DialsIntegrater(Integrater):
             "%s %s %s %s INTEGRATE" % (pname, xname, dname, sweep), html_filename
         )
 
-        import dials
         from dxtbx.serialize import load
 
         experiments = load.experiment_list(self._intgr_experiments_filename)
@@ -413,7 +412,7 @@ class DialsIntegrater(Integrater):
             % self.get_integrater_mosaic_min_mean_max()
         )
 
-        return self._intgr_integrated_filename
+        return self._intgr_integrated_reflections
 
     def _integrate_finish(self):
         """Finish off the integration by running dials.export."""
@@ -426,7 +425,7 @@ class DialsIntegrater(Integrater):
 
         if self._output_format == "hkl":
             exporter = self.ExportMtz()
-            exporter.set_reflections_filename(self._intgr_integrated_filename)
+            exporter.set_reflections_filename(self._intgr_integrated_reflections)
             mtz_filename = os.path.join(
                 self.get_working_directory(), "%s_integrated.mtz" % "dials"
             )
@@ -544,7 +543,7 @@ class DialsIntegrater(Integrater):
                     "Not reindexing to spacegroup %d (%s)"
                     % (self._intgr_spacegroup_number, self._intgr_reindex_operator)
                 )
-                return self._intgr_integrated_filename
+                return self._intgr_integrated_reflections
 
             if (
                 self._intgr_reindex_operator is None
@@ -554,7 +553,7 @@ class DialsIntegrater(Integrater):
                     "Not reindexing to spacegroup %d (%s)"
                     % (self._intgr_spacegroup_number, self._intgr_reindex_operator)
                 )
-                return self._intgr_integrated_filename
+                return self._intgr_integrated_reflections
 
             Debug.write(
                 "Reindexing to spacegroup %d (%s)"
@@ -581,7 +580,7 @@ class DialsIntegrater(Integrater):
             reindex.set_indexed_filename(self.get_integrated_reflections())
 
             reindex.run()
-            self._intgr_integrated_filename = reindex.get_reindexed_reflections_filename()
+            self._intgr_integrated_reflections = reindex.get_reindexed_reflections_filename()
             self._intgr_integrated_filename = (
                 reindex.get_reindexed_reflections_filename()
             )

--- a/Modules/Integrater/XDSIntegrater.py
+++ b/Modules/Integrater/XDSIntegrater.py
@@ -542,7 +542,6 @@ class XDSIntegrater(Integrater):
         integrate_hkl = os.path.join(self.get_working_directory(), "INTEGRATE.HKL")
 
         if PhilIndex.params.xia2.settings.input.format.dynamic_shadowing:
-            from libtbx import easy_pickle
             from dxtbx.serialize import load
             from dials.algorithms.shadowing.filter import filter_shadowed_reflections
 
@@ -557,10 +556,10 @@ class XDSIntegrater(Integrater):
                 .get_goniometer_shadow_masker()
             )
             if masker is not None:
-                integrate_pickle = integrate_hkl_to_reflection_pickle(
+                integrate_filename = integrate_hkl_to_reflection_file(
                     integrate_hkl, experiments_json, self.get_working_directory()
                 )
-                reflections = easy_pickle.load(integrate_pickle)
+                reflections = flex.reflection_table.from_file(integrate_filename)
 
                 import time
 
@@ -956,7 +955,7 @@ class XDSIntegrater(Integrater):
         return self._intgr_experiments_filename
 
 
-def integrate_hkl_to_reflection_pickle(
+def integrate_hkl_to_reflection_file(
     integrate_hkl, experiments_json, working_directory
 ):
     from xia2.Wrappers.Dials.ImportXDS import ImportXDS

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -295,7 +295,7 @@ class DataManager(object):
             intensities = miller.array(miller_set, data=data, sigmas=sigmas)
             intensities.set_observation_type_xray_intensity()
             intensities.set_info(
-                miller.array_info(source="DIALS", source_type="pickle")
+                miller.array_info(source="DIALS", source_type="mpack")
             )
             if return_batches:
                 batches = miller.array(miller_set, data=batches).set_info(
@@ -319,7 +319,7 @@ class DataManager(object):
             expt.crystal.update(cryst_reindexed)
 
     def export_reflections(self, filename):
-        self._reflections.as_pickle(filename)
+        self._reflections.as_msgpack_file(filename)
         return filename
 
     def export_experiments(self, filename):
@@ -399,7 +399,7 @@ class MultiCrystalScale(object):
         self._scaled = Scale(self._data_manager, self._params)
 
         self._data_manager.export_experiments("experiments_final.json")
-        self._data_manager.export_reflections("reflections_final.pickle")
+        self._data_manager.export_reflections("reflections_final.mpack")
 
         scaled_unmerged_mtz = py.path.local(self._scaled.scaled_unmerged_mtz)
         scaled_unmerged_mtz.copy(py.path.local("scaled_unmerged.mtz"))
@@ -512,10 +512,10 @@ class MultiCrystalScale(object):
             "tmp_experiments.json"
         )
         reflections_filename = self._data_manager.export_reflections(
-            "tmp_reflections.pickle"
+            "tmp_reflections.mpack"
         )
         cosym.add_experiments_json(experiments_filename)
-        cosym.add_reflections_pickle(reflections_filename)
+        cosym.add_reflections_file(reflections_filename)
         if self._params.symmetry.space_group is not None:
             cosym.set_space_group(self._params.symmetry.space_group.group())
         cosym.run()
@@ -525,7 +525,7 @@ class MultiCrystalScale(object):
         self._data_manager.experiments = load.experiment_list(
             self._experiments_filename, check_format=False
         )
-        self._data_manager.reflections = flex.reflection_table.from_pickle(
+        self._data_manager.reflections = flex.reflection_table.from_file(
             self._reflections_filename
         )
 
@@ -553,7 +553,7 @@ class MultiCrystalScale(object):
             cb_op_to_ref = crystal_symmetry.change_of_basis_op_to_reference_setting()
             self._data_manager.reindex(cb_op=cb_op_to_ref)
             self._experiments_filename = "experiments.json"
-            self._reflections_filename = "reflections.pickle"
+            self._reflections_filename = "reflections.mpack"
             self._data_manager.export_experiments(self._experiments_filename)
             self._data_manager.export_reflections(self._reflections_filename)
             return
@@ -566,11 +566,11 @@ class MultiCrystalScale(object):
             "%i_experiments_reindexed.json" % symmetry.get_xpid()
         )
         self._reflections_filename = (
-            "%i_reflections_reindexed.pickle" % symmetry.get_xpid()
+            "%i_reflections_reindexed.mpack" % symmetry.get_xpid()
         )
 
         experiments_filename = "tmp_experiments.json"
-        reflections_filename = "tmp_reflections.pickle"
+        reflections_filename = "tmp_reflections.mpack"
         self._data_manager.export_experiments(experiments_filename)
         self._data_manager.export_reflections(reflections_filename)
 
@@ -589,7 +589,7 @@ class MultiCrystalScale(object):
         self._data_manager.experiments = load.experiment_list(
             self._experiments_filename, check_format=False
         )
-        self._data_manager.reflections = flex.reflection_table.from_pickle(
+        self._data_manager.reflections = flex.reflection_table.from_file(
             self._reflections_filename
         )
 
@@ -611,7 +611,7 @@ class Scale(object):
         self._params = params
 
         self._experiments_filename = "experiments.json"
-        self._reflections_filename = "reflections.pickle"
+        self._reflections_filename = "reflections.mpack"
         self._data_manager.export_experiments(self._experiments_filename)
         self._data_manager.export_reflections(self._reflections_filename)
         self.best_unit_cell = None
@@ -639,7 +639,7 @@ class Scale(object):
         self._data_manager.experiments = load.experiment_list(
             self._experiments_filename, check_format=False
         )
-        self._data_manager.reflections = flex.reflection_table.from_pickle(
+        self._data_manager.reflections = flex.reflection_table.from_file(
             self._reflections_filename
         )
 
@@ -682,7 +682,7 @@ class Scale(object):
         tt_refiner = TwoThetaRefine()
         auto_logfiler(tt_refiner)
         tt_refiner.set_experiments([experiments_filename])
-        tt_refiner.set_pickles([reflections_filename])
+        tt_refiner.set_reflection_files([reflections_filename])
         tt_refiner.set_combine_crystal_models(combine_crystal_models)
         tt_refiner.run()
         unit_cell = tt_refiner.get_unit_cell()
@@ -695,7 +695,7 @@ class Scale(object):
         auto_logfiler(scaler)
         # scaler.set_surface_link(False) # multi-crystal
         scaler.add_experiments_json(self._experiments_filename)
-        scaler.add_reflections_pickle(self._reflections_filename)
+        scaler.add_reflections_file(self._reflections_filename)
         # scaler.set_surface_tie(self._params.scaling.surface_tie)
         lmax = self._params.scaling.secondary.lmax
         if lmax:
@@ -729,7 +729,7 @@ class Scale(object):
         self._data_manager.experiments = load.experiment_list(
             self._experiments_filename, check_format=False
         )
-        self._data_manager.reflections = flex.reflection_table.from_pickle(
+        self._data_manager.reflections = flex.reflection_table.from_file(
             self._reflections_filename
         )
         self._params.resolution.labels = "IPR,SIGIPR"

--- a/Modules/Refiner/DialsRefiner.py
+++ b/Modules/Refiner/DialsRefiner.py
@@ -92,17 +92,16 @@ class DialsRefiner(Refiner):
                 )
                 indexed_reflections = os.path.join(
                     self.get_working_directory(),
-                    "%s_indexed_reflections.pickle" % xsweep.get_name(),
+                    "%s_indexed_reflections.mpack" % xsweep.get_name(),
                 )
 
                 from dxtbx.serialize import dump
 
                 dump.experiment_list(experiments, indexed_experiments)
 
-                from libtbx import easy_pickle
                 from scitbx.array_family import flex
 
-                reflections = easy_pickle.load(
+                reflections = flex.from_file(
                     idxr.get_indexer_payload("indexed_filename")
                 )
                 sel = reflections["id"] == i
@@ -114,7 +113,7 @@ class DialsRefiner(Refiner):
                 # set indexed reflections to id == 0 and imageset_id == 0
                 reflections["id"].set_selected(reflections["id"] == i, 0)
                 reflections["imageset_id"] = flex.int(len(reflections), 0)
-                easy_pickle.dump(indexed_reflections, reflections)
+                reflections.as_msgpack_file(indexed_reflections)
 
             assert (
                 len(experiments.crystals()) == 1
@@ -188,7 +187,7 @@ class DialsRefiner(Refiner):
                 "experiments.json", self._refinr_experiments_filename
             )
             self.set_refiner_payload(
-                "reflections.pickle", self._refinr_indexed_filename
+                "reflections.mpack", self._refinr_indexed_filename
             )
 
             # this is the result of the cell refinement

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -1257,7 +1257,7 @@ class CommonScaler(Scaler):
             groups = {}
             self._scalr_cell_dict = {}
             tt_refine_experiments = []
-            tt_refine_pickles = []
+            tt_refine_reflections = []
             tt_refine_reindex_ops = []
             for epoch in self._sweep_handler.get_epochs():
                 si = self._sweep_handler.get_sweep_information(epoch)
@@ -1282,10 +1282,10 @@ class CommonScaler(Scaler):
                 auto_logfiler(tt_grouprefiner)
                 args = zip(*groups[pi])
                 tt_grouprefiner.set_experiments(args[0])
-                tt_grouprefiner.set_pickles(args[1])
+                tt_grouprefiner.set_reflection_files(args[1])
                 tt_grouprefiner.set_output_p4p(p4p_file)
                 tt_refine_experiments.extend(args[0])
-                tt_refine_pickles.extend(args[1])
+                tt_refine_reflections.extend(args[1])
                 tt_refine_reindex_ops.extend(args[2])
                 reindex_ops = args[2]
                 from cctbx.sgtbx import change_of_basis_op as cb_op
@@ -1332,7 +1332,7 @@ class CommonScaler(Scaler):
                 tt_refiner.set_output_p4p(p4p_file)
                 auto_logfiler(tt_refiner)
                 tt_refiner.set_experiments(tt_refine_experiments)
-                tt_refiner.set_pickles(tt_refine_pickles)
+                tt_refiner.set_reflection_files(tt_refine_reflections)
                 if self._spacegroup_reindex_operator is not None:
                     reindex_ops = [
                         (

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -476,7 +476,7 @@ class DialsScaler(Scaler):
             integrater.set_integrater_reindex_operator(
                 reindex_ops[epoch], reason="setting point group"
             )
-            integrater.set_output_format("pickle")
+            integrater.set_output_format("mpack")
             _ = integrater.get_integrater_intensities()
             # ^ This will give us the reflections in the correct point group
             si.set_reflections(integrater.get_integrated_reflections())
@@ -629,7 +629,7 @@ class DialsScaler(Scaler):
                     )
                     reindexed_refl_fpath = os.path.join(
                         self.get_working_directory(),
-                        str(counter) + "_reindexed_reflections.pickle",
+                        str(counter) + "_reindexed_reflections.mpack",
                     )
 
                     # if we are working with unified UB matrix then this should not
@@ -748,14 +748,14 @@ class DialsScaler(Scaler):
         if self._scaled_experiments and self._scaled_reflections:
             # going to continue-where-left-off
             self._scaler.add_experiments_json(self._scaled_experiments)
-            self._scaler.add_reflections_pickle(self._scaled_reflections)
+            self._scaler.add_reflections_file(self._scaled_reflections)
         else:
             for epoch in self._sweep_handler.get_epochs():
                 si = self._sweep_handler.get_sweep_information(epoch)
                 experiment = si.get_experiments()
                 reflections = si.get_reflections()
                 self._scaler.add_experiments_json(experiment)
-                self._scaler.add_reflections_pickle(reflections)
+                self._scaler.add_reflections_file(reflections)
 
         self._scaler.set_scaled_unmerged_mtz(scaled_unmerged_mtz_path)
         self._scaler.set_scaled_mtz(scaled_mtz_path)
@@ -804,7 +804,7 @@ class DialsScaler(Scaler):
         FileHandler.record_data_file(scaled_unmerged_mtz_path)
         FileHandler.record_data_file(scaled_mtz_path)
 
-        # make it so that only scaled.pickle and scaled_experiments.json are
+        # make it so that only scaled.mpack and scaled_experiments.json are
         # the files that dials.scale knows about, so that if scale is called again,
         # scaling resumes from where it left off.
         self._scaler.clear_datafiles()
@@ -1116,7 +1116,7 @@ class DialsScalerHelper(object):
         for i, epoch in enumerate(sweep_handler.get_epochs()):
             si = sweep_handler.get_sweep_information(epoch)
             nums = fmt % i
-            r = flex.reflection_table.from_pickle(si.get_reflections())
+            r = flex.reflection_table.from_file(si.get_reflections())
             if len(set(r["id"]).difference(set([-1]))) > 1:
                 raise ValueError("Only single-experiment tables expected")
             old_id = list(r.experiment_identifiers().keys())[0]
@@ -1127,7 +1127,7 @@ class DialsScalerHelper(object):
             fname = os.path.join(
                 self.get_working_directory(), "split_reflections_%s.mpack" % nums
             )
-            r.as_pickle(fname)
+            r.as_msgpack_file(fname)
             si.set_reflections(fname)
         return sweep_handler
 
@@ -1246,7 +1246,7 @@ Passing multple datasets to indexer_jiffy but not set multisweep=True"""
         integrater.set_integrater_reindex_operator(
             reindex_op, reason="eliminated lattice"
         )
-        integrater.set_output_format("pickle")
+        integrater.set_output_format("mpack")
         _ = integrater.get_integrater_intensities()
         # ^ This will give us the reflections in the correct point group
         si.set_reflections(integrater.get_integrated_reflections())

--- a/Modules/Scaler/rebatch.py
+++ b/Modules/Scaler/rebatch.py
@@ -27,7 +27,6 @@ def compact_batches(batches):
         for k, g in groupby(enumerate(batches), lambda i_x: i_x[0] - i_x[1])
     ]
 
-import time
 
 def rebatch(
     hklin,
@@ -43,7 +42,6 @@ def rebatch(
 ):
     """Need to implement: include batch range, exclude batches, add N to
     batches, start batches at N."""
-    t0 = time.time()
     if include_range is None:
         include_range = []
     if exclude_range is None:
@@ -60,8 +58,6 @@ def rebatch(
     if exclude_batches:
         exclude_range = [(b[0], b[-1]) for b in compact_batches(exclude_batches)]
 
-    t1 = time.time()
-
     mtz_obj = mtz.object(file_name=hklin)
 
     batch_column = None
@@ -77,30 +73,19 @@ def rebatch(
     if not batch_column:
         raise RuntimeError("no BATCH column found in %s" % hklin)
 
-    t2 = time.time()
-
     batches = [b.num() for b in mtz_obj.batches()]
     batch_column_values = batch_column.extract_values(not_a_number_substitute=-1)
 
     valid = flex.bool()
     offset = 0
 
-    t3 = time.time()
-    t4 = time.time()
-    t5 = time.time()
-
     if exclude_range:
-        print(exclude_range)
         exclude_sel = flex.bool(batch_column_values.size(), False)
         for (start, end) in exclude_range:
             exclude_sel.set_selected(
                 (batch_column_values >= start) & (batch_column_values <= end), True
             )
-        print(exclude_sel.size(), exclude_sel.iselection().size())
         mtz_obj.delete_reflections(exclude_sel.iselection())
-
-        t4 = time.time()
-        print("***", t4 - t3)
 
     elif include_range:
         exclude_sel = flex.bool(batch_column_values.size(), True)
@@ -109,8 +94,6 @@ def rebatch(
                 (batch_column_values >= start) & (batch_column_values <= end), False
             )
         mtz_obj.delete_reflections(exclude_sel.iselection())
-
-        t5 = time.time()
 
     # modify batch columns, and also the batch headers
 
@@ -129,8 +112,6 @@ def rebatch(
 
         batch_column.set_values(values=batch_column_values, selection_valid=valid)
 
-    t6 = time.time()
-
     if pname and xname and dname:
 
         for c in mtz_obj.crystals():
@@ -141,27 +122,11 @@ def rebatch(
             c.set_project_name(pname)
             c.set_name(xname)
 
-    t7 = time.time()
-
     # and write this lot out as hklout
 
     mtz_obj.write(file_name=hklout)
 
-    t8 = time.time()
-
     new_batches = (min(batches) + offset, max(batches) + offset)
-
-    t9 = time.time()
-
-    print(t1 - t0)
-    print(t2 - t1)
-    print(t3 - t2)
-    print(t4 - t3)
-    print(t5 - t4)
-    print(t6 - t5)
-    print(t7 - t6)
-    print(t8 - t7)
-    print(t9 - t8)
 
     return new_batches
 

--- a/Schema/Interfaces/Integrater.py
+++ b/Schema/Interfaces/Integrater.py
@@ -108,7 +108,7 @@ class Integrater(FrameProcessor):
         self._intgr_hklout = None
         self._output_format = (
             "hkl"
-        )  #'hkl' or 'pickle', if pickle then self._intgr_hklout
+        )  #'hkl' or 'mpack', if mpack then self._intgr_hklout
         # returns a refl table.
 
         # a place to store the project, crystal, wavelength, sweep information
@@ -606,7 +606,7 @@ class Integrater(FrameProcessor):
 
     def set_output_format(self, output_format="hkl"):
         Debug.write("setting integrator output format to %s" % output_format)
-        assert output_format in ["hkl", "pickle"]
+        assert output_format in ["hkl", "mpack"]
         self._output_format = output_format
 
     def get_integrater_indexer(self):

--- a/Test/Modules/Scaler/test_DialsScalerHelper.py
+++ b/Test/Modules/Scaler/test_DialsScalerHelper.py
@@ -131,10 +131,10 @@ def test_dials_symmetry_decide_pointgroup(
     dump.experiment_list(
         generated_exp(space_group=experiments_spacegroup), "test_exp.json"
     )
-    generate_reflections_in_sg(reflection_spacegroup).as_pickle("test_refl.pickle")
+    generate_reflections_in_sg(reflection_spacegroup).as_msgpack_file("test_refl.mpack")
 
     symmetry_analyser = helper.dials_symmetry_decide_pointgroup(
-        ["test_exp.json"], ["test_refl.pickle"]
+        ["test_exp.json"], ["test_refl.mpack"]
     )
 
     # Note : instabilities have been observed in the order of the end of the
@@ -153,8 +153,8 @@ def test_assign_identifiers(helper):
     experiments = []
     reflections = []
     for i in range(0, 3):
-        refl_path, exp_path = ("test_refl_%s.pickle" % i, "test_exp_%s.json" % i)
-        generate_test_refl().as_pickle(refl_path)
+        refl_path, exp_path = ("test_refl_%s.mpack" % i, "test_exp_%s.json" % i)
+        generate_test_refl().as_msgpack_file(refl_path)
         dump.experiment_list(generated_exp(), exp_path)
         experiments.append(exp_path)
         reflections.append(refl_path)
@@ -222,14 +222,14 @@ def test_split_experiments(number_of_experiments, helper):
     id, giving single datasets with unique ids from 0..n-1"""
     sweephandler = simple_sweep_handler(number_of_experiments)
     exp_path = "test_experiments.json"
-    refl_path = "test_reflections.pickle"
+    refl_path = "test_reflections.mpack"
     dump.experiment_list(
         generated_exp(number_of_experiments, assign_ids=True), exp_path
     )
     reflections = flex.reflection_table()
     for i in range(number_of_experiments):
         reflections.extend(generate_test_refl(id_=i, assign_id=True))
-    reflections.as_pickle(refl_path)
+    reflections.as_msgpack_file(refl_path)
     # Now call split_experiments and inspect handler to check result
     sweephandler = helper.split_experiments(exp_path, refl_path, sweephandler)
     check_data_in_sweep_handler(sweephandler)
@@ -254,8 +254,8 @@ def test_assign_and_return_datasets(helper):
     sweephandler = simple_sweep_handler(n)
     for i in range(0, n):
         si = sweephandler.get_sweep_information(i)
-        refl_path, exp_path = ("test_refl_%s.pickle" % i, "test_exp_%s.json" % i)
-        generate_test_refl().as_pickle(refl_path)
+        refl_path, exp_path = ("test_refl_%s.mpack" % i, "test_exp_%s.json" % i)
+        generate_test_refl().as_msgpack_file(refl_path)
         dump.experiment_list(generated_exp(), exp_path)
         si.set_experiments(exp_path)
         si.set_reflections(refl_path)
@@ -374,8 +374,8 @@ def test_dials_symmetry_indexer_jiffy(helper, refiner_lattices, expected_output)
     reflections = []
     refiners = []
     for i in range(0, n):
-        refl_path, exp_path = ("test_refl_%s.pickle" % i, "test_exp_%s.json" % i)
-        generate_reflections_in_sg("P 2", id_=i, assign_id=True).as_pickle(refl_path)
+        refl_path, exp_path = ("test_refl_%s.mpack" % i, "test_exp_%s.json" % i)
+        generate_reflections_in_sg("P 2", id_=i, assign_id=True).as_msgpack_file(refl_path)
         dump.experiment_list(generated_exp(space_group="P 2", id_=i), exp_path)
         experiments.append(exp_path)
         reflections.append(refl_path)

--- a/Test/Wrappers/Dials/test_dials_wrappers.py
+++ b/Test/Wrappers/Dials/test_dials_wrappers.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 import mock
-import pytest
 from libtbx.test_utils import approx_equal
 
 
@@ -117,7 +116,7 @@ def exercise_dials_wrappers(template, nproc=None):
     import shutil
 
     shutil.copy(indexer.get_experiments_filename(), "copy.json")
-    shutil.copy(indexer.get_indexed_filename(), "copy.pickle")
+    shutil.copy(indexer.get_indexed_filename(), "copy.mpack")
     print("Begin combining")
     from xia2.Wrappers.Dials.CombineExperiments import CombineExperiments
 
@@ -125,7 +124,7 @@ def exercise_dials_wrappers(template, nproc=None):
     exporter.add_experiments(indexer.get_experiments_filename())
     exporter.add_experiments("copy.json")
     exporter.add_reflections(indexer.get_indexed_filename())
-    exporter.add_reflections("copy.pickle")
+    exporter.add_reflections("copy.mpack")
     exporter.run()
     print("".join(exporter.get_all_output()))
     print("Done combining")

--- a/Wrappers/Dials/AssignUniqueIdentifiers.py
+++ b/Wrappers/Dials/AssignUniqueIdentifiers.py
@@ -58,7 +58,7 @@ def DialsAssignIdentifiers(DriverType=None):
             if not self._output_reflections_filename:
                 self._output_reflections_filename = os.path.join(
                     self.get_working_directory(),
-                    "%d_assigned_reflections.pickle" % self.get_xpid(),
+                    "%d_assigned_reflections.mpack" % self.get_xpid(),
                 )
 
             self.add_command_line(

--- a/Wrappers/Dials/CombineExperiments.py
+++ b/Wrappers/Dials/CombineExperiments.py
@@ -109,7 +109,7 @@ def CombineExperiments(DriverType=None):
             if not self._combined_reflections_filename:
                 self._combined_reflections_filename = os.path.join(
                     self.get_working_directory(),
-                    "%s_combined_reflections.pickle" % self.get_xpid(),
+                    "%s_combined_reflections.mpack" % self.get_xpid(),
                 )
             self.add_command_line(
                 "output.reflections_filename=%s" % self._combined_reflections_filename

--- a/Wrappers/Dials/Cosym.py
+++ b/Wrappers/Dials/Cosym.py
@@ -27,7 +27,7 @@ def DialsCosym(DriverType=None, decay_correction=None):
 
             # input and output files
             self._experiments_json = []
-            self._reflections_pickle = []
+            self._reflection_files = []
 
             self._space_group = None
             self._json = None
@@ -37,8 +37,8 @@ def DialsCosym(DriverType=None, decay_correction=None):
         def add_experiments_json(self, experiments_json):
             self._experiments_json.append(experiments_json)
 
-        def add_reflections_pickle(self, reflections_pickle):
-            self._reflections_pickle.append(reflections_pickle)
+        def add_reflections_file(self, reflections_file):
+            self._reflection_files.append(reflections_file)
 
         def get_reindexed_experiments(self):
             return self._reindexed_experiments
@@ -54,10 +54,10 @@ def DialsCosym(DriverType=None, decay_correction=None):
 
         def run(self):
             assert len(self._experiments_json)
-            assert len(self._reflections_pickle)
-            assert len(self._experiments_json) == len(self._reflections_pickle)
+            assert len(self._reflection_files)
+            assert len(self._experiments_json) == len(self._reflection_files)
 
-            for f in self._experiments_json + self._reflections_pickle:
+            for f in self._experiments_json + self._reflection_files:
                 assert os.path.isfile(f)
                 self.add_command_line(f)
 
@@ -71,7 +71,7 @@ def DialsCosym(DriverType=None, decay_correction=None):
             )
             self._reindexed_reflections = os.path.join(
                 self.get_working_directory(),
-                "%i_reindexed_reflections.pickle" % self.get_xpid(),
+                "%i_reindexed_reflections.mpack" % self.get_xpid(),
             )
 
             self.add_command_line(

--- a/Wrappers/Dials/GenerateMask.py
+++ b/Wrappers/Dials/GenerateMask.py
@@ -75,7 +75,7 @@ def GenerateMask(DriverType=None):
             if self._output_experiments_filename is None:
                 self._output_experiments_filename = os.path.join(
                     self.get_working_directory(),
-                    "%s_experiments.pickle" % self.get_xpid(),
+                    "%s_experiments.mpack" % self.get_xpid(),
                 )
             self.add_command_line('output.mask="%s"' % self._output_mask_filename)
             self.add_command_line(

--- a/Wrappers/Dials/ImportXDS.py
+++ b/Wrappers/Dials/ImportXDS.py
@@ -56,7 +56,7 @@ def ImportXDS(DriverType=None):
 
             if self._spot_xds is not None:
                 self._reflection_filename = os.path.join(
-                    self.get_working_directory(), "%s_spot_xds.pickle" % self.get_xpid()
+                    self.get_working_directory(), "%s_spot_xds.mpack" % self.get_xpid()
                 )
                 self.add_command_line("%s" % self._spot_xds)
                 self.add_command_line("output.filename=%s" % self._reflection_filename)
@@ -65,7 +65,7 @@ def ImportXDS(DriverType=None):
             elif self._integrate_hkl is not None:
                 self._reflection_filename = os.path.join(
                     self.get_working_directory(),
-                    "%s_integrate_hkl.pickle" % self.get_xpid(),
+                    "%s_integrate_hkl.mpack" % self.get_xpid(),
                 )
                 assert self._experiments_json is not None
                 self.add_command_line("%s" % self._integrate_hkl)

--- a/Wrappers/Dials/Index.py
+++ b/Wrappers/Dials/Index.py
@@ -219,7 +219,7 @@ def Index(DriverType=None):
                 self.get_working_directory(), "%d_experiments.json" % self.get_xpid()
             )
             self._indexed_filename = os.path.join(
-                self.get_working_directory(), "%d_indexed.pickle" % self.get_xpid()
+                self.get_working_directory(), "%d_indexed.mpack" % self.get_xpid()
             )
             self.add_command_line("output.experiments=%s" % self._experiment_filename)
             self.add_command_line("output.reflections=%s" % self._indexed_filename)
@@ -259,7 +259,7 @@ def Index(DriverType=None):
             from dxtbx.serialize import load
 
             self._experiment_list = load.experiment_list(self._experiment_filename)
-            self._reflections = flex.reflection_table.from_pickle(
+            self._reflections = flex.reflection_table.from_file(
                 self._indexed_filename
             )
 

--- a/Wrappers/Dials/Integrate.py
+++ b/Wrappers/Dials/Integrate.py
@@ -134,7 +134,7 @@ def Integrate(DriverType=None):
                 self.add_command_line("mp.njobs=%i" % njob)
             self.add_command_line(("input.reflections=%s" % self._reflections_filename))
             self._integrated_reflections = os.path.join(
-                self.get_working_directory(), "%d_integrated.pickle" % self.get_xpid()
+                self.get_working_directory(), "%d_integrated.mpack" % self.get_xpid()
             )
             self._integrated_experiments = os.path.join(
                 self.get_working_directory(),

--- a/Wrappers/Dials/Refine.py
+++ b/Wrappers/Dials/Refine.py
@@ -107,7 +107,7 @@ def Refine(DriverType=None):
                 "output.experiments=%s" % self._refined_experiments_filename
             )
             self._refined_filename = os.path.join(
-                self.get_working_directory(), "%s_refined.pickle" % self.get_xpid()
+                self.get_working_directory(), "%s_refined.mpack" % self.get_xpid()
             )
             self.add_command_line("output.reflections=%s" % self._refined_filename)
             if self._reflections_per_degree is not None:

--- a/Wrappers/Dials/Reindex.py
+++ b/Wrappers/Dials/Reindex.py
@@ -90,7 +90,7 @@ def Reindex(DriverType=None):
                 self.add_command_line(self._indexed_filename)
                 if not self._reindexed_reflections_filename:
                     self._reindexed_reflections_filename = os.path.join(
-                        wd, "%d_reflections_reindexed.pickle" % self.get_xpid()
+                        wd, "%d_reflections_reindexed.mpack" % self.get_xpid()
                     )
                 self.add_command_line(
                     "output.reflections=%s" % self._reindexed_reflections_filename

--- a/Wrappers/Dials/Scale.py
+++ b/Wrappers/Dials/Scale.py
@@ -105,7 +105,7 @@ def DialsScale(DriverType=None, decay_correction=None):
             self._experiments_json.append(experiments_json)
 
         def add_reflections_file(self, reflections_file):
-            self._reflections_file.append(reflections_file)
+            self._reflection_files.append(reflections_file)
 
         def clear_datafiles(self):
             self._experiments_json = []

--- a/Wrappers/Dials/Scale.py
+++ b/Wrappers/Dials/Scale.py
@@ -53,7 +53,7 @@ def DialsScale(DriverType=None, decay_correction=None):
             self._unmerged_reflections = None
 
             self._experiments_json = []
-            self._reflections_pickle = []
+            self._reflection_files = []
 
             # this flag indicates that the input reflections are already
             # scaled and just need merging e.g. from XDS/XSCALE.
@@ -104,12 +104,12 @@ def DialsScale(DriverType=None, decay_correction=None):
         def add_experiments_json(self, experiments_json):
             self._experiments_json.append(experiments_json)
 
-        def add_reflections_pickle(self, reflections_pickle):
-            self._reflections_pickle.append(reflections_pickle)
+        def add_reflections_file(self, reflections_file):
+            self._reflections_file.append(reflections_file)
 
         def clear_datafiles(self):
             self._experiments_json = []
-            self._reflections_pickle = []
+            self._reflection_files = []
             self._scaled_experiments = []
             self._scaled_reflections = []
 
@@ -223,10 +223,10 @@ def DialsScale(DriverType=None, decay_correction=None):
             # been run previously
 
             assert len(self._experiments_json)
-            assert len(self._reflections_pickle)
-            assert len(self._experiments_json) == len(self._reflections_pickle)
+            assert len(self._reflection_files)
+            assert len(self._experiments_json) == len(self._reflection_files)
 
-            for f in self._experiments_json + self._reflections_pickle:
+            for f in self._experiments_json + self._reflection_files:
                 assert os.path.isfile(f)
                 self.add_command_line(f)
 
@@ -299,7 +299,7 @@ def DialsScale(DriverType=None, decay_correction=None):
             if not self._scaled_reflections:
                 self._scaled_reflections = os.path.join(
                     self.get_working_directory(),
-                    "%i_scaled_reflections.pickle" % self.get_xpid(),
+                    "%i_scaled_reflections.mpack" % self.get_xpid(),
                 )
             if not self._unmerged_reflections:
                 self._unmerged_reflections = os.path.join(
@@ -363,7 +363,7 @@ if __name__ == "__main__":
     auto_logfiler(s)
 
     s.add_experiments_json(args[0])
-    s.add_reflections_pickle(args[1])
+    s.add_reflections_file(args[1])
     s.set_full_matrix(False)
     s.set_model("kb")
 

--- a/Wrappers/Dials/Spotfinder.py
+++ b/Wrappers/Dials/Spotfinder.py
@@ -30,7 +30,7 @@ def Spotfinder(DriverType=None):
 
             self._input_sweep_filename = None
             self._output_sweep_filename = None
-            self._input_spot_filename = "strong.pickle"
+            self._input_spot_filename = "strong.mpack"
             self._scan_ranges = []
             self._nspots = 0
             self._min_spot_size = None

--- a/Wrappers/Dials/Symmetry.py
+++ b/Wrappers/Dials/Symmetry.py
@@ -175,7 +175,7 @@ def DialsSymmetry(DriverType=None):
                 if not self._output_reflections_filename:
                     self._output_reflections_filename = os.path.join(
                         self.get_working_directory(),
-                        "%d_reindexed_reflections.pickle" % self.get_xpid(),
+                        "%d_reindexed_reflections.mpack" % self.get_xpid(),
                     )
 
                 self.add_command_line(

--- a/Wrappers/Dials/TwoThetaRefine.py
+++ b/Wrappers/Dials/TwoThetaRefine.py
@@ -33,7 +33,7 @@ def TwoThetaRefine(DriverType=None):
             self._reindexed_reflections = None
 
             self._experiments = []
-            self._pickles = []
+            self._reflection_files = []
             self._phil_file = None
             self._combine_crystal_models = True
 
@@ -52,11 +52,11 @@ def TwoThetaRefine(DriverType=None):
         def get_experiments(self):
             return self._experiments
 
-        def set_pickles(self, pickles):
-            self._pickles = pickles
+        def set_reflection_files(self, reflection_files):
+            self._reflection_files = reflection_files
 
-        def get_pickles(self):
-            return self._pickles
+        def get_reflection_files(self):
+            return self._reflection_files
 
         def set_phil_file(self, phil_file):
             self._phil_file = phil_file
@@ -108,7 +108,7 @@ def TwoThetaRefine(DriverType=None):
 
                 self._reindexed_experiments, self._reindexed_reflections = [], []
                 for e, p, op in zip(
-                    self._experiments, self._pickles, self._reindexing_operators
+                    self._experiments, self._reflection_files, self._reindexing_operators
                 ):
                     reindexer = Reindex()
                     reindexer.set_cb_op(op)
@@ -152,13 +152,13 @@ def TwoThetaRefine(DriverType=None):
             if self._reindexing_operators:
                 for experiment in self._reindexed_experiments:
                     self.add_command_line(experiment)
-                for pickle in self._reindexed_reflections:
-                    self.add_command_line(pickle)
+                for reflection_file in self._reindexed_reflections:
+                    self.add_command_line(reflection_file)
             else:
                 for experiment in self._experiments:
                     self.add_command_line(experiment)
-                for pickle in self._pickles:
-                    self.add_command_line(pickle)
+                for reflection_file in self._reflection_files:
+                    self.add_command_line(reflection_file)
             self.add_command_line(
                 "combine_crystal_models=%s" % self._combine_crystal_models
             )

--- a/command_line/multi_crystal_analysis.py
+++ b/command_line/multi_crystal_analysis.py
@@ -444,7 +444,7 @@ def run():
     # The script usage
     usage = (
         "usage: xia2.multi_crystal_analysis [options] [param.phil] "
-        "experiments.json reflections.pickle"
+        "experiments.json reflections.mpack"
     )
 
     # Create the parser

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -1160,14 +1160,13 @@ higher resolution. A typical resolution cutoff based on CC1/2 is around 0.3-0.5.
 class xia2_report(xia2_report_base):
     def __init__(self, unmerged_mtz, params, base_dir=None):
 
-        from iotbx.reflection_file_reader import any_reflection_file
+        import iotbx.mtz
 
         self.unmerged_mtz = unmerged_mtz
         self.params = params
 
-        reader = any_reflection_file(unmerged_mtz)
-        assert reader.file_type() == "ccp4_mtz"
-        arrays = reader.as_miller_arrays(merge_equivalents=False)
+        self.mtz_object = iotbx.mtz.object(unmerged_mtz)
+        arrays = self.mtz_object.as_miller_arrays(merge_equivalents=False, auto_anomalous=True)
 
         self.intensities = None
         self.batches = None
@@ -1189,7 +1188,6 @@ class xia2_report(xia2_report_base):
 
         assert self.intensities is not None
         assert self.batches is not None
-        self.mtz_object = reader.file_content()
 
         crystal_name = (
             filter(
@@ -1229,9 +1227,9 @@ class xia2_report(xia2_report_base):
 
         self._compute_merging_stats()
 
-        if params.anomalous:
-            self.intensities = self.intensities.as_anomalous_array()
-            self.batches = self.batches.as_anomalous_array()
+        if not params.anomalous:
+            self.intensities = self.intensities.as_non_anomalous_array()
+            self.batches = self.batches.as_non_anomalous_array()
 
         self.intensities.setup_binner(n_bins=self.params.resolution_bins)
         self.merged_intensities = self.intensities.merge_equivalents().array()

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -1160,13 +1160,14 @@ higher resolution. A typical resolution cutoff based on CC1/2 is around 0.3-0.5.
 class xia2_report(xia2_report_base):
     def __init__(self, unmerged_mtz, params, base_dir=None):
 
-        import iotbx.mtz
+        from iotbx.reflection_file_reader import any_reflection_file
 
         self.unmerged_mtz = unmerged_mtz
         self.params = params
 
-        self.mtz_object = iotbx.mtz.object(unmerged_mtz)
-        arrays = self.mtz_object.as_miller_arrays(merge_equivalents=False, auto_anomalous=True)
+        reader = any_reflection_file(unmerged_mtz)
+        assert reader.file_type() == "ccp4_mtz"
+        arrays = reader.as_miller_arrays(merge_equivalents=False)
 
         self.intensities = None
         self.batches = None
@@ -1188,6 +1189,7 @@ class xia2_report(xia2_report_base):
 
         assert self.intensities is not None
         assert self.batches is not None
+        self.mtz_object = reader.file_content()
 
         crystal_name = (
             filter(
@@ -1227,9 +1229,9 @@ class xia2_report(xia2_report_base):
 
         self._compute_merging_stats()
 
-        if not params.anomalous:
-            self.intensities = self.intensities.as_non_anomalous_array()
-            self.batches = self.batches.as_non_anomalous_array()
+        if params.anomalous:
+            self.intensities = self.intensities.as_anomalous_array()
+            self.batches = self.batches.as_anomalous_array()
 
         self.intensities.setup_binner(n_bins=self.params.resolution_bins)
         self.merged_intensities = self.intensities.merge_equivalents().array()


### PR DESCRIPTION
This makes the necessary changes to xia2 now that msgpack is the default reflection file format in dials (dials/dials#743). All tests pass with `$ pytest --regression-full -n auto` apart from 2 tests which fail tolerance tests (I think these were failing before the msgpack changes were merged in to dials master).