### PR TITLE
Partial revert of msgpack changes

### DIFF
--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -307,7 +307,7 @@ class DialsIndexer(Indexer):
                 "%s_%s_experiments.json" % (spotfinder.get_xpid(), xsweep.get_name())
             )
             spotfinder.set_input_spot_filename(
-                "%s_%s_strong.mpack" % (spotfinder.get_xpid(), xsweep.get_name())
+                "%s_%s_strong.pickle" % (spotfinder.get_xpid(), xsweep.get_name())
             )
             if PhilIndex.params.dials.fast_mode:
                 wedges = self._index_select_images_i(imageset)
@@ -831,7 +831,7 @@ class DialsIndexer(Indexer):
         miller_indices = reflections["miller_index"]
         miller_indices = miller_indices.select(miller_indices != (0, 0, 0))
         # it isn't necessarily the 'p1_cell', but it should be the cell that
-        # corresponds to the miller indices in the indexed.mpack
+        # corresponds to the miller indices in the indexed.pickle
         symmetry = crystal.symmetry(unit_cell=uctbx.unit_cell(self._p1_cell))
         miller_set = miller.set(symmetry, miller_indices)
         d_max, d_min = miller_set.d_max_min()

--- a/Modules/Indexer/XDSIndexer.py
+++ b/Modules/Indexer/XDSIndexer.py
@@ -470,8 +470,8 @@ class XDSIndexer(IndexerSingleSweep):
             spotfinder.run()
             export = self.DialsExportSpotXDS()
             export.set_input_data_file(
-                "reflections.mpack",
-                spotfinder.get_output_data_file("reflections.mpack"),
+                "reflections.pickle",
+                spotfinder.get_output_data_file("reflections.pickle"),
             )
             export.run()
 

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -236,7 +236,7 @@ class DialsIntegrater(Integrater):
         )
         experiments = load.experiment_list(self._intgr_experiments_filename)
         experiment = experiments[0]
-        self._intgr_indexed_filename = refiner.get_refiner_payload("reflections.mpack")
+        self._intgr_indexed_filename = refiner.get_refiner_payload("reflections.pickle")
 
         # this is the result of the cell refinement
         self._intgr_cell = experiment.crystal.get_unit_cell().parameters()
@@ -531,7 +531,7 @@ class DialsIntegrater(Integrater):
 
             return hklout
 
-        elif self._output_format == "mpack":
+        elif self._output_format == "pickle":
 
             if (
                 self._intgr_reindex_operator is None

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -294,7 +294,9 @@ class DataManager(object):
             )
             intensities = miller.array(miller_set, data=data, sigmas=sigmas)
             intensities.set_observation_type_xray_intensity()
-            intensities.set_info(miller.array_info(source="DIALS", source_type="mpack"))
+            intensities.set_info(
+                miller.array_info(source="DIALS", source_type="pickle")
+            )
             if return_batches:
                 batches = miller.array(miller_set, data=batches).set_info(
                     intensities.info()
@@ -317,7 +319,7 @@ class DataManager(object):
             expt.crystal.update(cryst_reindexed)
 
     def export_reflections(self, filename):
-        self._reflections.as_msgpack_file(filename)
+        self._reflections.as_pickle(filename)
         return filename
 
     def export_experiments(self, filename):
@@ -397,7 +399,7 @@ class MultiCrystalScale(object):
         self._scaled = Scale(self._data_manager, self._params)
 
         self._data_manager.export_experiments("experiments_final.json")
-        self._data_manager.export_reflections("reflections_final.mpack")
+        self._data_manager.export_reflections("reflections_final.pickle")
 
         scaled_unmerged_mtz = py.path.local(self._scaled.scaled_unmerged_mtz)
         scaled_unmerged_mtz.copy(py.path.local("scaled_unmerged.mtz"))
@@ -510,7 +512,7 @@ class MultiCrystalScale(object):
             "tmp_experiments.json"
         )
         reflections_filename = self._data_manager.export_reflections(
-            "tmp_reflections.mpack"
+            "tmp_reflections.pickle"
         )
         cosym.add_experiments_json(experiments_filename)
         cosym.add_reflections_file(reflections_filename)
@@ -551,7 +553,7 @@ class MultiCrystalScale(object):
             cb_op_to_ref = crystal_symmetry.change_of_basis_op_to_reference_setting()
             self._data_manager.reindex(cb_op=cb_op_to_ref)
             self._experiments_filename = "experiments.json"
-            self._reflections_filename = "reflections.mpack"
+            self._reflections_filename = "reflections.pickle"
             self._data_manager.export_experiments(self._experiments_filename)
             self._data_manager.export_reflections(self._reflections_filename)
             return
@@ -564,11 +566,11 @@ class MultiCrystalScale(object):
             "%i_experiments_reindexed.json" % symmetry.get_xpid()
         )
         self._reflections_filename = (
-            "%i_reflections_reindexed.mpack" % symmetry.get_xpid()
+            "%i_reflections_reindexed.pickle" % symmetry.get_xpid()
         )
 
         experiments_filename = "tmp_experiments.json"
-        reflections_filename = "tmp_reflections.mpack"
+        reflections_filename = "tmp_reflections.pickle"
         self._data_manager.export_experiments(experiments_filename)
         self._data_manager.export_reflections(reflections_filename)
 
@@ -609,7 +611,7 @@ class Scale(object):
         self._params = params
 
         self._experiments_filename = "experiments.json"
-        self._reflections_filename = "reflections.mpack"
+        self._reflections_filename = "reflections.pickle"
         self._data_manager.export_experiments(self._experiments_filename)
         self._data_manager.export_reflections(self._reflections_filename)
         self.best_unit_cell = None

--- a/Modules/Refiner/DialsRefiner.py
+++ b/Modules/Refiner/DialsRefiner.py
@@ -94,7 +94,7 @@ class DialsRefiner(Refiner):
                 )
                 indexed_reflections = os.path.join(
                     self.get_working_directory(),
-                    "%s_indexed_reflections.mpack" % xsweep.get_name(),
+                    "%s_indexed_reflections.pickle" % xsweep.get_name(),
                 )
 
                 from dxtbx.serialize import dump
@@ -113,7 +113,7 @@ class DialsRefiner(Refiner):
                 # set indexed reflections to id == 0 and imageset_id == 0
                 reflections["id"].set_selected(reflections["id"] == i, 0)
                 reflections["imageset_id"] = flex.int(len(reflections), 0)
-                reflections.as_msgpack_file(indexed_reflections)
+                easy_pickle.dump(indexed_reflections, reflections)
 
             assert (
                 len(experiments.crystals()) == 1
@@ -186,7 +186,9 @@ class DialsRefiner(Refiner):
             self.set_refiner_payload(
                 "experiments.json", self._refinr_experiments_filename
             )
-            self.set_refiner_payload("reflections.mpack", self._refinr_indexed_filename)
+            self.set_refiner_payload(
+                "reflections.pickle", self._refinr_indexed_filename
+            )
 
             # this is the result of the cell refinement
             self._refinr_cell = experiments.crystals()[0].get_unit_cell().parameters()

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -1098,7 +1098,7 @@ class DialsScalerHelper(object):
             nums = fmt % i
             si.set_reflections(
                 os.path.join(
-                    self.get_working_directory(), "split_reflections_%s.mpack" % nums
+                    self.get_working_directory(), "split_reflections_%s.pickle" % nums
                 )
             )
             si.set_experiments(
@@ -1125,7 +1125,7 @@ class DialsScalerHelper(object):
             r["id"].set_selected(r["id"] == old_id, i)
             r.experiment_identifiers()[i] = exp_id
             fname = os.path.join(
-                self.get_working_directory(), "split_reflections_%s.mpack" % nums
+                self.get_working_directory(), "split_reflections_%s.pickle" % nums
             )
             r.as_pickle(fname)
             si.set_reflections(fname)

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -476,7 +476,7 @@ class DialsScaler(Scaler):
             integrater.set_integrater_reindex_operator(
                 reindex_ops[epoch], reason="setting point group"
             )
-            integrater.set_output_format("mpack")
+            integrater.set_output_format("pickle")
             _ = integrater.get_integrater_intensities()
             # ^ This will give us the reflections in the correct point group
             si.set_reflections(integrater.get_integrated_reflections())
@@ -629,7 +629,7 @@ class DialsScaler(Scaler):
                     )
                     reindexed_refl_fpath = os.path.join(
                         self.get_working_directory(),
-                        str(counter) + "_reindexed_reflections.mpack",
+                        str(counter) + "_reindexed_reflections.pickle",
                     )
 
                     # if we are working with unified UB matrix then this should not
@@ -804,7 +804,7 @@ class DialsScaler(Scaler):
         FileHandler.record_data_file(scaled_unmerged_mtz_path)
         FileHandler.record_data_file(scaled_mtz_path)
 
-        # make it so that only scaled.mpack and scaled_experiments.json are
+        # make it so that only scaled.pickle and scaled_experiments.json are
         # the files that dials.scale knows about, so that if scale is called again,
         # scaling resumes from where it left off.
         self._scaler.clear_datafiles()
@@ -1127,7 +1127,7 @@ class DialsScalerHelper(object):
             fname = os.path.join(
                 self.get_working_directory(), "split_reflections_%s.mpack" % nums
             )
-            r.as_msgpack_file(fname)
+            r.as_pickle(fname)
             si.set_reflections(fname)
         return sweep_handler
 
@@ -1246,7 +1246,7 @@ Passing multple datasets to indexer_jiffy but not set multisweep=True"""
         integrater.set_integrater_reindex_operator(
             reindex_op, reason="eliminated lattice"
         )
-        integrater.set_output_format("mpack")
+        integrater.set_output_format("pickle")
         _ = integrater.get_integrater_intensities()
         # ^ This will give us the reflections in the correct point group
         si.set_reflections(integrater.get_integrated_reflections())

--- a/Schema/Interfaces/Integrater.py
+++ b/Schema/Interfaces/Integrater.py
@@ -106,7 +106,9 @@ class Integrater(FrameProcessor):
         # the output reflections
         self._intgr_hklout_raw = None
         self._intgr_hklout = None
-        self._output_format = "hkl"  #'hkl' or 'mpack', if mpack then self._intgr_hklout
+        self._output_format = (
+            "hkl"
+        )  #'hkl' or 'pickle', if pickle then self._intgr_hklout
         # returns a refl table.
 
         # a place to store the project, crystal, wavelength, sweep information
@@ -604,7 +606,7 @@ class Integrater(FrameProcessor):
 
     def set_output_format(self, output_format="hkl"):
         Debug.write("setting integrator output format to %s" % output_format)
-        assert output_format in ["hkl", "mpack"]
+        assert output_format in ["hkl", "pickle"]
         self._output_format = output_format
 
     def get_integrater_indexer(self):

--- a/Test/Modules/Scaler/test_DialsScalerHelper.py
+++ b/Test/Modules/Scaler/test_DialsScalerHelper.py
@@ -131,10 +131,10 @@ def test_dials_symmetry_decide_pointgroup(
     dump.experiment_list(
         generated_exp(space_group=experiments_spacegroup), "test_exp.json"
     )
-    generate_reflections_in_sg(reflection_spacegroup).as_msgpack_file("test_refl.mpack")
+    generate_reflections_in_sg(reflection_spacegroup).as_pickle("test_refl.pickle")
 
     symmetry_analyser = helper.dials_symmetry_decide_pointgroup(
-        ["test_exp.json"], ["test_refl.mpack"]
+        ["test_exp.json"], ["test_refl.pickle"]
     )
 
     # Note : instabilities have been observed in the order of the end of the
@@ -153,8 +153,8 @@ def test_assign_identifiers(helper):
     experiments = []
     reflections = []
     for i in range(0, 3):
-        refl_path, exp_path = ("test_refl_%s.mpack" % i, "test_exp_%s.json" % i)
-        generate_test_refl().as_msgpack_file(refl_path)
+        refl_path, exp_path = ("test_refl_%s.pickle" % i, "test_exp_%s.json" % i)
+        generate_test_refl().as_pickle(refl_path)
         dump.experiment_list(generated_exp(), exp_path)
         experiments.append(exp_path)
         reflections.append(refl_path)
@@ -222,14 +222,14 @@ def test_split_experiments(number_of_experiments, helper):
     id, giving single datasets with unique ids from 0..n-1"""
     sweephandler = simple_sweep_handler(number_of_experiments)
     exp_path = "test_experiments.json"
-    refl_path = "test_reflections.mpack"
+    refl_path = "test_reflections.pickle"
     dump.experiment_list(
         generated_exp(number_of_experiments, assign_ids=True), exp_path
     )
     reflections = flex.reflection_table()
     for i in range(number_of_experiments):
         reflections.extend(generate_test_refl(id_=i, assign_id=True))
-    reflections.as_msgpack_file(refl_path)
+    reflections.as_pickle(refl_path)
     # Now call split_experiments and inspect handler to check result
     sweephandler = helper.split_experiments(exp_path, refl_path, sweephandler)
     check_data_in_sweep_handler(sweephandler)
@@ -254,8 +254,8 @@ def test_assign_and_return_datasets(helper):
     sweephandler = simple_sweep_handler(n)
     for i in range(0, n):
         si = sweephandler.get_sweep_information(i)
-        refl_path, exp_path = ("test_refl_%s.mpack" % i, "test_exp_%s.json" % i)
-        generate_test_refl().as_msgpack_file(refl_path)
+        refl_path, exp_path = ("test_refl_%s.pickle" % i, "test_exp_%s.json" % i)
+        generate_test_refl().as_pickle(refl_path)
         dump.experiment_list(generated_exp(), exp_path)
         si.set_experiments(exp_path)
         si.set_reflections(refl_path)
@@ -374,10 +374,8 @@ def test_dials_symmetry_indexer_jiffy(helper, refiner_lattices, expected_output)
     reflections = []
     refiners = []
     for i in range(0, n):
-        refl_path, exp_path = ("test_refl_%s.mpack" % i, "test_exp_%s.json" % i)
-        generate_reflections_in_sg("P 2", id_=i, assign_id=True).as_msgpack_file(
-            refl_path
-        )
+        refl_path, exp_path = ("test_refl_%s.pickle" % i, "test_exp_%s.json" % i)
+        generate_reflections_in_sg("P 2", id_=i, assign_id=True).as_pickle(refl_path)
         dump.experiment_list(generated_exp(space_group="P 2", id_=i), exp_path)
         experiments.append(exp_path)
         reflections.append(refl_path)

--- a/Test/Wrappers/Dials/test_dials_wrappers.py
+++ b/Test/Wrappers/Dials/test_dials_wrappers.py
@@ -116,7 +116,7 @@ def exercise_dials_wrappers(template, nproc=None):
     import shutil
 
     shutil.copy(indexer.get_experiments_filename(), "copy.json")
-    shutil.copy(indexer.get_indexed_filename(), "copy.mpack")
+    shutil.copy(indexer.get_indexed_filename(), "copy.pickle")
     print("Begin combining")
     from xia2.Wrappers.Dials.CombineExperiments import CombineExperiments
 
@@ -124,7 +124,7 @@ def exercise_dials_wrappers(template, nproc=None):
     exporter.add_experiments(indexer.get_experiments_filename())
     exporter.add_experiments("copy.json")
     exporter.add_reflections(indexer.get_indexed_filename())
-    exporter.add_reflections("copy.mpack")
+    exporter.add_reflections("copy.pickle")
     exporter.run()
     print("".join(exporter.get_all_output()))
     print("Done combining")

--- a/Wrappers/Dials/AssignUniqueIdentifiers.py
+++ b/Wrappers/Dials/AssignUniqueIdentifiers.py
@@ -58,7 +58,7 @@ def DialsAssignIdentifiers(DriverType=None):
             if not self._output_reflections_filename:
                 self._output_reflections_filename = os.path.join(
                     self.get_working_directory(),
-                    "%d_assigned_reflections.mpack" % self.get_xpid(),
+                    "%d_assigned_reflections.pickle" % self.get_xpid(),
                 )
 
             self.add_command_line(

--- a/Wrappers/Dials/CombineExperiments.py
+++ b/Wrappers/Dials/CombineExperiments.py
@@ -109,7 +109,7 @@ def CombineExperiments(DriverType=None):
             if not self._combined_reflections_filename:
                 self._combined_reflections_filename = os.path.join(
                     self.get_working_directory(),
-                    "%s_combined_reflections.mpack" % self.get_xpid(),
+                    "%s_combined_reflections.pickle" % self.get_xpid(),
                 )
             self.add_command_line(
                 "output.reflections_filename=%s" % self._combined_reflections_filename

--- a/Wrappers/Dials/Cosym.py
+++ b/Wrappers/Dials/Cosym.py
@@ -71,7 +71,7 @@ def DialsCosym(DriverType=None, decay_correction=None):
             )
             self._reindexed_reflections = os.path.join(
                 self.get_working_directory(),
-                "%i_reindexed_reflections.mpack" % self.get_xpid(),
+                "%i_reindexed_reflections.pickle" % self.get_xpid(),
             )
 
             self.add_command_line(

--- a/Wrappers/Dials/GenerateMask.py
+++ b/Wrappers/Dials/GenerateMask.py
@@ -75,7 +75,7 @@ def GenerateMask(DriverType=None):
             if self._output_experiments_filename is None:
                 self._output_experiments_filename = os.path.join(
                     self.get_working_directory(),
-                    "%s_experiments.mpack" % self.get_xpid(),
+                    "%s_experiments.pickle" % self.get_xpid(),
                 )
             self.add_command_line('output.mask="%s"' % self._output_mask_filename)
             self.add_command_line(

--- a/Wrappers/Dials/ImportXDS.py
+++ b/Wrappers/Dials/ImportXDS.py
@@ -56,7 +56,7 @@ def ImportXDS(DriverType=None):
 
             if self._spot_xds is not None:
                 self._reflection_filename = os.path.join(
-                    self.get_working_directory(), "%s_spot_xds.mpack" % self.get_xpid()
+                    self.get_working_directory(), "%s_spot_xds.pickle" % self.get_xpid()
                 )
                 self.add_command_line("%s" % self._spot_xds)
                 self.add_command_line("output.filename=%s" % self._reflection_filename)
@@ -65,7 +65,7 @@ def ImportXDS(DriverType=None):
             elif self._integrate_hkl is not None:
                 self._reflection_filename = os.path.join(
                     self.get_working_directory(),
-                    "%s_integrate_hkl.mpack" % self.get_xpid(),
+                    "%s_integrate_hkl.pickle" % self.get_xpid(),
                 )
                 assert self._experiments_json is not None
                 self.add_command_line("%s" % self._integrate_hkl)

--- a/Wrappers/Dials/Index.py
+++ b/Wrappers/Dials/Index.py
@@ -219,7 +219,7 @@ def Index(DriverType=None):
                 self.get_working_directory(), "%d_experiments.json" % self.get_xpid()
             )
             self._indexed_filename = os.path.join(
-                self.get_working_directory(), "%d_indexed.mpack" % self.get_xpid()
+                self.get_working_directory(), "%d_indexed.pickle" % self.get_xpid()
             )
             self.add_command_line("output.experiments=%s" % self._experiment_filename)
             self.add_command_line("output.reflections=%s" % self._indexed_filename)

--- a/Wrappers/Dials/Integrate.py
+++ b/Wrappers/Dials/Integrate.py
@@ -134,7 +134,7 @@ def Integrate(DriverType=None):
                 self.add_command_line("mp.njobs=%i" % njob)
             self.add_command_line(("input.reflections=%s" % self._reflections_filename))
             self._integrated_reflections = os.path.join(
-                self.get_working_directory(), "%d_integrated.mpack" % self.get_xpid()
+                self.get_working_directory(), "%d_integrated.pickle" % self.get_xpid()
             )
             self._integrated_experiments = os.path.join(
                 self.get_working_directory(),

--- a/Wrappers/Dials/Refine.py
+++ b/Wrappers/Dials/Refine.py
@@ -107,7 +107,7 @@ def Refine(DriverType=None):
                 "output.experiments=%s" % self._refined_experiments_filename
             )
             self._refined_filename = os.path.join(
-                self.get_working_directory(), "%s_refined.mpack" % self.get_xpid()
+                self.get_working_directory(), "%s_refined.pickle" % self.get_xpid()
             )
             self.add_command_line("output.reflections=%s" % self._refined_filename)
             if self._reflections_per_degree is not None:

--- a/Wrappers/Dials/Reindex.py
+++ b/Wrappers/Dials/Reindex.py
@@ -90,7 +90,7 @@ def Reindex(DriverType=None):
                 self.add_command_line(self._indexed_filename)
                 if not self._reindexed_reflections_filename:
                     self._reindexed_reflections_filename = os.path.join(
-                        wd, "%d_reflections_reindexed.mpack" % self.get_xpid()
+                        wd, "%d_reflections_reindexed.pickle" % self.get_xpid()
                     )
                 self.add_command_line(
                     "output.reflections=%s" % self._reindexed_reflections_filename

--- a/Wrappers/Dials/Scale.py
+++ b/Wrappers/Dials/Scale.py
@@ -299,7 +299,7 @@ def DialsScale(DriverType=None, decay_correction=None):
             if not self._scaled_reflections:
                 self._scaled_reflections = os.path.join(
                     self.get_working_directory(),
-                    "%i_scaled_reflections.mpack" % self.get_xpid(),
+                    "%i_scaled_reflections.pickle" % self.get_xpid(),
                 )
             if not self._unmerged_reflections:
                 self._unmerged_reflections = os.path.join(

--- a/Wrappers/Dials/Spotfinder.py
+++ b/Wrappers/Dials/Spotfinder.py
@@ -30,7 +30,7 @@ def Spotfinder(DriverType=None):
 
             self._input_sweep_filename = None
             self._output_sweep_filename = None
-            self._input_spot_filename = "strong.mpack"
+            self._input_spot_filename = "strong.pickle"
             self._scan_ranges = []
             self._nspots = 0
             self._min_spot_size = None

--- a/Wrappers/Dials/Symmetry.py
+++ b/Wrappers/Dials/Symmetry.py
@@ -175,7 +175,7 @@ def DialsSymmetry(DriverType=None):
                 if not self._output_reflections_filename:
                     self._output_reflections_filename = os.path.join(
                         self.get_working_directory(),
-                        "%d_reindexed_reflections.mpack" % self.get_xpid(),
+                        "%d_reindexed_reflections.pickle" % self.get_xpid(),
                     )
 
                 self.add_command_line(

--- a/command_line/multi_crystal_analysis.py
+++ b/command_line/multi_crystal_analysis.py
@@ -437,7 +437,7 @@ def run():
     # The script usage
     usage = (
         "usage: xia2.multi_crystal_analysis [options] [param.phil] "
-        "experiments.json reflections.mpack"
+        "experiments.json reflections.pickle"
     )
 
     # Create the parser


### PR DESCRIPTION
Revert only the filenames and writing, keeping the changes for reading as they will work independent of reflection file format. Revisit the output file format once msgpack performance issues with large reflection files have been addressed.