### PR TITLE
more useful error message from check_return_code

### DIFF
--- a/Driver/DefaultDriver.py
+++ b/Driver/DefaultDriver.py
@@ -165,12 +165,12 @@ class DefaultDriver(object):
 
         self._working_environment[name] = [value]
 
-        if not name in self._working_environment_exclusive:
+        if name not in self._working_environment_exclusive:
             self._working_environment_exclusive.append(name)
 
     def add_working_environment(self, name, value):
         """Add an extra token to the environment for processing."""
-        if not name in self._working_environment:
+        if name not in self._working_environment:
             self._working_environment[name] = []
         self._working_environment[name].append(value)
 
@@ -181,7 +181,7 @@ class DefaultDriver(object):
     def add_scratch_directory(self, directory):
         """Add a scratch directory."""
 
-        if not directory in self._scratch_directories:
+        if directory not in self._scratch_directories:
             self._scratch_directories.append(directory)
 
     def set_task(self, task):

--- a/Driver/DefaultDriver.py
+++ b/Driver/DefaultDriver.py
@@ -340,7 +340,7 @@ class DefaultDriver(object):
             log_file_extra = ": see %s for more details" % self.get_log_file()
         else:
             log_file_extra = ""
-        executable = "%s" % os.path.split(self._executable)[-1]
+        executable = "%s" % os.path.basename(self._executable)
 
         if os.name == "nt":
             if code == 3:
@@ -491,7 +491,7 @@ class DefaultDriver(object):
         if self._log_file:
             # close the existing log file: also add a comment at the end containing the
             # command-line (replacing working directory & executable path for brevity)
-            command_line = "%s " % os.path.split(self._executable)[-1]
+            command_line = "%s " % os.path.basename(self._executable)
             for c in self._command_line:
                 command_line += " '%s'" % c.replace(
                     self._working_directory + os.sep, ""
@@ -516,7 +516,7 @@ class DefaultDriver(object):
                     Debug.write(line.rstrip("\n"), strip=False)
         elif hasattr(self, "_runtime_log") and self._runtime_log:
             if self._executable:
-                command_line = "%s " % os.path.split(self._executable)[-1]
+                command_line = "%s " % os.path.basename(self._executable)
                 for c in self._command_line:
                     command_line += " '%s'" % c.replace(
                         self._working_directory + os.sep, ""

--- a/Driver/DefaultDriver.py
+++ b/Driver/DefaultDriver.py
@@ -46,10 +46,10 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import time
+import signal
 
 import xia2.Driver.timing
 from xia2.Driver.DriverHelper import (
-    check_return_code,
     error_abrt,
     error_fp,
     error_kill,
@@ -327,7 +327,58 @@ class DefaultDriver(object):
         self.check_for_error_text(self._standard_output_records[-30:])
         # next check the status
 
-        check_return_code(self.status())
+        self.check_return_code()
+
+    def check_return_code(self):
+        """Check the return code for indications of errors."""
+
+        code = self.status()
+        if not code:
+            return
+
+        if self.get_log_file():
+            log_file_extra = ": see %s for more details" % self.get_log_file()
+        else:
+            log_file_extra = ""
+        executable = "%s" % os.path.split(self._executable)[-1]
+
+        if os.name == "nt":
+            if code == 3:
+                raise RuntimeError("child error")
+
+        else:
+            # return codes in POSIX are -ve
+
+            segv = signal.SIGSEGV * -1
+            kill = signal.SIGKILL * -1
+            abrt = signal.SIGABRT * -1
+
+            if code == segv:
+                raise RuntimeError(
+                    "{executable}: child segmentation fault{log_file_extra}".format(
+                        executable=executable, log_file_extra=log_file_extra
+                    )
+                )
+
+            if code == kill:
+                raise RuntimeError(
+                    "{executable} killed{log_file_extra}".format(
+                        executable=executable, log_file_extra=log_file_extra
+                    )
+                )
+
+            if code == abrt:
+                raise RuntimeError(
+                    "{executable} failed{log_file_extra}".format(
+                        executable=executable, log_file_extra=log_file_extra
+                    )
+                )
+
+        raise RuntimeError(
+            "{executable} subprocess failed with exitcode {code}{log_file_extra}".format(
+                executable=executable, code=code, log_file_extra=log_file_extra
+            )
+        )
 
     def _input(self, record):
         """Pass record into the child programs standard input."""

--- a/Driver/DriverHelper.py
+++ b/Driver/DriverHelper.py
@@ -312,36 +312,6 @@ def error_python_traceback(records):
         raise Sorry(error_messages[0])
 
 
-def check_return_code(code):
-    """Check the return code for indications of errors."""
-
-    if not code:
-        return
-
-    if os.name == "nt":
-        if code == 3:
-            raise RuntimeError("child error")
-
-    else:
-
-        # return codes in POSIX are -ve
-
-        segv = signal.SIGSEGV * -1
-        kill = signal.SIGKILL * -1
-        abrt = signal.SIGABRT * -1
-
-        if code == segv:
-            raise RuntimeError("child segmentation fault")
-
-        if code == kill:
-            raise RuntimeError("subprocess killed")
-
-        if code == abrt:
-            raise RuntimeError("process failed")
-
-    raise RuntimeError("subprocess failed with exitcode {code}".format(code=code))
-
-
 executable_exists_cache = {}
 
 


### PR DESCRIPTION
A side effect of 516b23e152c3adc45b4665d171ea79c65e62fe00 is sometimes see error messages such as the following:
```
------------------- Autoindexing SWEEP1 --------------------
Error: subprocess failed with exitcode 42
Please send the contents of xia2.txt, xia2.error and xia2-debug.txt to:
xia2.support@gmail.com
```
After the changes in this pull request, the error message would now be:
```
------------------- Autoindexing SWEEP1 --------------------
Error: dials.index subprocess failed with exitcode 42: see /path/to/DEFAULT/NATIVE/SWEEP1/index/5_dials.index.log for more details
Please send the contents of xia2.txt, xia2.error and xia2-debug.txt to:
xia2.support@gmail.com
```
