### PR TITLE
Refactoring CCP4ScalerA scale_prepare

### DIFF
--- a/Modules/Scaler/CCP4ScalerHelpers.py
+++ b/Modules/Scaler/CCP4ScalerHelpers.py
@@ -337,7 +337,7 @@ class CCP4ScalerHelper(object):
         probably_twinned = symmetry.get_probably_twinned()
 
         Debug.write("Pointgroup: %s (%s)" % (pointgroup, reindex_op))
-
+        Debug.write("X1698: %s: %s" % (pointgroup, reindex_op))
         return pointgroup, reindex_op, need_to_return, probably_twinned
 
     def pointless_indexer_multisweep(self, hklin, refiners):
@@ -410,6 +410,7 @@ class CCP4ScalerHelper(object):
         probably_twinned = pointless.get_probably_twinned()
 
         Debug.write("Pointgroup: %s (%s)" % (pointgroup, reindex_op))
+        Debug.write("X1698: %s: %s" % (pointgroup, reindex_op))
 
         return pointgroup, reindex_op, need_to_return, probably_twinned
 


### PR DESCRIPTION
As part of trying to fix DialsScaler, I decided to refactor CCP4ScalerA to make the logic easier to follow. The refactoring is of the scale_prepare step, up until the start of the 'test indexing consistency'  step (so refactor of lattice tests and pointgroup tests).

The first commit tidies up the code, removing variables that are only defined and used once (or worse 0 times) to make it easier to read, as well as separate out each pass into the three cases: input pointgroup set, multisweep (and not input pointgroup) and everything else, to remove heavily nested code. Also a big chunk of repeated code for multisweep indexing is factored out.

The second commit then separates out each case into a separate function and removes a lot of code which turns out was not doing a whole lot for the input pointgroup and multisweep cases. This makes it much easier to read the code and follow the decision logic. This revealed that the indexer_jiffys were called twice with the same input - so the initial result is kept and the second call removed.
The result is surprising, but for each case, if you take the original code and delete the if/else paths not taken, then it is easy to see that the same result is obtained. 

The tests pass, and I've processed several datasets with both branches and diffed the xia2.txt which show the result is the same.
