### PR TITLE
Start replacing Chatter/Debug streams with logging

### DIFF
--- a/command_line/xia2_main.py
+++ b/command_line/xia2_main.py
@@ -13,6 +13,7 @@ import traceback
 from dials.util import Sorry
 from dials.util.version import dials_version
 import xia2.Driver.timing
+import xia2.Handlers.Streams
 import xia2.XIA2Version
 from xia2.Applications.xia2_helpers import process_one_sweep
 from xia2.Applications.xia2_main import (
@@ -332,6 +333,9 @@ def run():
         if ccp4_version is not None:
             print("CCP4 %s" % ccp4_version)
         sys.exit()
+
+    xia2.Handlers.Streams.setup_logging(logfile="xia2.txt", debugfile="xia2-debug.txt")
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
 
     try:
         check_environment()

--- a/command_line/xia2_main.py
+++ b/command_line/xia2_main.py
@@ -25,7 +25,6 @@ from xia2.Applications.xia2_main import (
 from xia2.Handlers.Citations import Citations
 from xia2.Handlers.Environment import Environment
 from xia2.Handlers.Files import cleanup
-from xia2.Handlers.Flags import Flags
 from xia2.Handlers.Streams import Chatter, Debug
 
 
@@ -53,12 +52,9 @@ def xia2_main(stop_after=None):
     start_time = time.time()
 
     CommandLine = get_command_line()
-    start_dir = Flags.get_starting_directory()
 
     # check that something useful has been assigned for processing...
     xtals = CommandLine.get_xinfo().get_crystals()
-
-    no_images = True
 
     for name in xtals.keys():
         xtal = xtals[name]
@@ -68,8 +64,6 @@ def xia2_main(stop_after=None):
             Chatter.write("-----------------------------------" + "-" * len(name))
             Chatter.write("| No images assigned for crystal %s |" % name)
             Chatter.write("-----------------------------------" + "-" * len(name))
-        else:
-            no_images = False
 
     args = []
 
@@ -187,10 +181,6 @@ def xia2_main(stop_after=None):
             if (i_job % njob) == 0:
                 arg[0].driver_type = default_driver_type
 
-        if mp_params.type == "qsub":
-            method = "sge"
-        else:
-            method = "multiprocessing"
         nproc = mp_params.nproc
         qsub_command = mp_params.qsub_command or "qsub"
         qsub_command = "%s -V -cwd -pe smp %d" % (qsub_command, nproc)
@@ -201,7 +191,6 @@ def xia2_main(stop_after=None):
             process_one_sweep,
             args,
             processes=njob,
-            # method=method,
             method="multiprocessing",
             qsub_command=qsub_command,
             preserve_order=True,


### PR DESCRIPTION
This commit adds an adapter function that replaces the backend file
operations in Chatter/Debug/Stdout streams with calls to Python logging.
With this we can support code that uses Chatter/Debug as well as code
that uses logging.

NB:
* if Chatter/Debug should use the logging backend then this should be
  set up before the first .write() call happens. Otherwise the output
  file will be created.
* all messages coming in via Chatter/Stdout have loglevel info, all
  messages coming in via Debug have loglevel debug.
* the adapter only goes one way. If a command that does not set up
  the logging backend calls code that uses logging then that output
  does not go into the log.

Adding this would be the first step towards #267.
The next step would be to use `setup_logging()` in all xia2 dispatchers, at which point we can remove the `reconfigure_streams_to_logging()` function and roll its changes into the `Chatter`/`Debug`/`Stdout` classes.
From there on we can use logging as normal throughout xia2 and have it co-exist with the stream classes for a while.
Finally we can deprecate and remove the stream classes.