### PR TITLE
Deprecation warnings

### DIFF
--- a/Applications/xia2setup.py
+++ b/Applications/xia2setup.py
@@ -107,7 +107,7 @@ def is_image_name(filename):
 
         end = filename.split(".")[-1]
         try:
-            if not ".log." in filename and len(end) > 1:
+            if ".log." not in filename and len(end) > 1:
                 return True
         except Exception:
             pass
@@ -315,7 +315,7 @@ def print_sweeps(out=sys.stdout):
 
             wavelength = s.get_wavelength()
 
-            if not wavelength in wavelengths:
+            if wavelength not in wavelengths:
                 have_wavelength = False
                 for w in wavelengths:
                     if abs(w - wavelength) < wavelength_tolerance:
@@ -590,7 +590,7 @@ def write_xinfo(filename, directories, template=None, hdf5_master_files=None):
     try:
         os.makedirs(directory)
     except OSError as e:
-        if not "File exists" in str(e):
+        if "File exists" not in str(e):
             raise
 
     # FIXME should I have some exception handling in here...?
@@ -651,7 +651,7 @@ def run():
         try:
             os.makedirs(directory)
         except OSError as e:
-            if not "File exists" in str(e):
+            if "File exists" not in str(e):
                 raise e
         os.chdir(directory)
 

--- a/Applications/xia2setup.py
+++ b/Applications/xia2setup.py
@@ -187,22 +187,6 @@ def get_template(f):
     return template
 
 
-def save_experiments(filename):
-    from xia2.Schema import imageset_cache
-    from dxtbx.model.experiment_list import ExperimentList
-    from dxtbx.model.experiment_list import ExperimentListFactory
-    from dxtbx.serialize import dump
-
-    experiments = ExperimentList([])
-    for imagesets in imageset_cache.values():
-        for imageset in imagesets.values():
-            experiments.extend(
-                ExperimentListFactory.from_imageset_and_crystal(imageset, None)
-            )
-
-    dump.experiment_list(experiments, filename, compact=True)
-
-
 def parse_sequence(sequence_file):
     sequence = ""
 

--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -135,14 +135,12 @@ class DialsIndexer(Indexer):
 
     def Refine(self):
         refine = _Refine()
-        params = PhilIndex.params.dials.refine
+        params = PhilIndex.params.dials
         refine.set_working_directory(self.get_working_directory())
         refine.set_scan_varying(False)
-        refine.set_outlier_algorithm(PhilIndex.params.dials.outlier.algorithm)
-        refine.set_close_to_spindle_cutoff(
-            PhilIndex.params.dials.close_to_spindle_cutoff
-        )
-        if PhilIndex.params.dials.fix_geometry:
+        refine.set_outlier_algorithm(params.outlier.algorithm)
+        refine.set_close_to_spindle_cutoff(params.close_to_spindle_cutoff)
+        if params.fix_geometry:
             refine.set_detector_fix("all")
             refine.set_beam_fix("all")
         auto_logfiler(refine)
@@ -362,7 +360,7 @@ class DialsIndexer(Indexer):
                 detectblanks.set_reflections_filename(spot_filename)
                 detectblanks.run()
                 json = detectblanks.get_results()
-                offset = imageset.get_scan().get_image_range()[0]
+                # offset = imageset.get_scan().get_image_range()[0]
                 blank_regions = json["strong"]["blank_regions"]
                 if len(blank_regions):
                     blank_regions = [(int(s), int(e)) for s, e in blank_regions]
@@ -463,13 +461,13 @@ class DialsIndexer(Indexer):
                 try:
                     indexer_fft3d = self._do_indexing(method="fft3d")
                     nref_3d, rmsd_3d = indexer_fft3d.get_nref_rmsds()
-                except Exception as e:
+                except Exception as e:  # noqa F841.  Flake8 misses use of `e` below.
                     nref_3d = None
                     rmsd_3d = None
                 try:
                     indexer_fft1d = self._do_indexing(method="fft1d")
                     nref_1d, rmsd_1d = indexer_fft1d.get_nref_rmsds()
-                except Exception as e:
+                except Exception as e:  # noqa F841.  Flake8 misses use of `e` below.
                     nref_1d = None
                     rmsd_1d = None
 
@@ -487,7 +485,8 @@ class DialsIndexer(Indexer):
                 elif nref_3d is not None:
                     indexer = indexer_fft3d
                 else:
-                    raise RuntimeError(e)
+                    # Flake8 doesn't recognise this as `e` from above.
+                    raise RuntimeError(e)  # noqa F821.
 
         else:
             indexer = self._do_indexing(method=PhilIndex.params.dials.index.method)
@@ -718,7 +717,6 @@ class DialsIndexer(Indexer):
         if self._indxr_input_cell:
             indexer.set_indexer_input_cell(self._indxr_input_cell)
             Debug.write("Set cell: %f %f %f %f %f %f" % self._indxr_input_cell)
-            original_cell = self._indxr_input_cell
 
         if method is None:
             if PhilIndex.params.dials.index.method is None:

--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -265,15 +265,13 @@ class DialsIndexer(Indexer):
 
             # FIXME need to adjust this to allow (say) three chunks of images
 
-            from dxtbx.serialize import dump
             from dxtbx.model.experiment_list import ExperimentListFactory
 
             sweep_filename = os.path.join(
                 self.get_working_directory(), "%s_import.expt" % xsweep.get_name()
             )
-            dump.experiment_list(
-                ExperimentListFactory.from_imageset_and_crystal(imageset, None),
-                sweep_filename,
+            ExperimentListFactory.from_imageset_and_crystal(imageset, None).as_file(
+                sweep_filename
             )
 
             genmask = self.GenerateMask()

--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -461,15 +461,17 @@ class DialsIndexer(Indexer):
                 try:
                     indexer_fft3d = self._do_indexing(method="fft3d")
                     nref_3d, rmsd_3d = indexer_fft3d.get_nref_rmsds()
-                except Exception as e:  # noqa F841.  Flake8 misses use of `e` below.
+                except Exception as e:
                     nref_3d = None
                     rmsd_3d = None
+                    indexing_failure = e
                 try:
                     indexer_fft1d = self._do_indexing(method="fft1d")
                     nref_1d, rmsd_1d = indexer_fft1d.get_nref_rmsds()
-                except Exception as e:  # noqa F841.  Flake8 misses use of `e` below.
+                except Exception as e:
                     nref_1d = None
                     rmsd_1d = None
+                    indexing_failure = e
 
                 if (
                     nref_1d is not None
@@ -485,8 +487,7 @@ class DialsIndexer(Indexer):
                 elif nref_3d is not None:
                     indexer = indexer_fft3d
                 else:
-                    # Flake8 doesn't recognise this as `e` from above.
-                    raise RuntimeError(e)  # noqa F821.
+                    raise RuntimeError(indexing_failure)
 
         else:
             indexer = self._do_indexing(method=PhilIndex.params.dials.index.method)

--- a/Modules/Indexer/XDSIndexer.py
+++ b/Modules/Indexer/XDSIndexer.py
@@ -345,7 +345,6 @@ class XDSIndexer(IndexerSingleSweep):
         if PhilIndex.params.xia2.settings.input.format.dynamic_shadowing:
             # find the region of the scan with the least predicted shadow
             # to use for background determination in XDS INIT step
-            from dxtbx.serialize import dump
             from dxtbx.model.experiment_list import ExperimentListFactory
 
             imageset = self._indxr_imagesets[0]

--- a/Modules/Indexer/XDSIndexer.py
+++ b/Modules/Indexer/XDSIndexer.py
@@ -352,9 +352,8 @@ class XDSIndexer(IndexerSingleSweep):
             sweep_filename = os.path.join(
                 self.get_working_directory(), "%s_indexed.expt" % xsweep.get_name()
             )
-            dump.experiment_list(
-                ExperimentListFactory.from_imageset_and_crystal(imageset, None),
-                sweep_filename,
+            ExperimentListFactory.from_imageset_and_crystal(imageset, None).as_file(
+                sweep_filename
             )
 
             from xia2.Wrappers.Dials.ShadowPlot import ShadowPlot

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -12,7 +12,7 @@ from libtbx import Auto
 import iotbx.phil
 from cctbx import miller
 from cctbx import sgtbx
-from dxtbx.serialize import dump, load
+from dxtbx.serialize import load
 from dxtbx.model import ExperimentList
 
 from dials.array_family import flex
@@ -291,7 +291,7 @@ class DataManager(object):
         return filename
 
     def export_experiments(self, filename):
-        dump.experiment_list(self._experiments, filename)
+        self._experiments.as_file(filename)
         return filename
 
 

--- a/Modules/Refiner/DialsRefiner.py
+++ b/Modules/Refiner/DialsRefiner.py
@@ -95,9 +95,7 @@ class DialsRefiner(Refiner):
                     self.get_working_directory(), "%s_indexed.refl" % xsweep.get_name()
                 )
 
-                from dxtbx.serialize import dump
-
-                dump.experiment_list(experiments, indexed_experiments)
+                experiments.as_file(indexed_experiments)
 
                 reflections = flex.reflection_table.from_file(
                     idxr.get_indexer_payload("indexed_filename")
@@ -116,8 +114,6 @@ class DialsRefiner(Refiner):
             assert (
                 len(experiments.crystals()) == 1
             )  # currently only handle one lattice/sweep
-            crystal_model = experiments.crystals()[0]
-            lattice = idxr.get_indexer_lattice()
 
             from dxtbx.serialize import load
 

--- a/Test/Modules/Scaler/test_DialsScalerHelper.py
+++ b/Test/Modules/Scaler/test_DialsScalerHelper.py
@@ -8,7 +8,7 @@ from dials.algorithms.symmetry.cosym._generate_test_data import generate_intensi
 from dials.array_family import flex
 from dxtbx.model.experiment_list import ExperimentList
 from dxtbx.model import Crystal, Scan, Beam, Experiment
-from dxtbx.serialize import dump, load
+from dxtbx.serialize import load
 
 
 flex.set_random_seed(42)
@@ -133,7 +133,7 @@ def test_dials_symmetry_decide_pointgroup(
 ):
     """Test for the dials_symmetry_decide_pointgroup helper function """
 
-    dump.experiment_list(generated_exp(space_group=experiments_spacegroup), "test.expt")
+    generated_exp(space_group=experiments_spacegroup).as_file("test.expt")
     generate_reflections_in_sg(reflection_spacegroup).as_pickle("test.refl")
 
     symmetry_analyser = helper.dials_symmetry_decide_pointgroup(
@@ -158,7 +158,7 @@ def test_assign_identifiers(helper):
     for i in range(0, 3):
         refl_path, exp_path = ("test_%s.refl" % i, "test_%s.expt" % i)
         generate_test_refl().as_pickle(refl_path)
-        dump.experiment_list(generated_exp(), exp_path)
+        generated_exp().as_file(exp_path)
         experiments.append(exp_path)
         reflections.append(refl_path)
     assigner = helper.assign_dataset_identifiers(experiments, reflections)
@@ -226,9 +226,7 @@ def test_split_experiments(number_of_experiments, helper):
     sweephandler = simple_sweep_handler(number_of_experiments)
     exp_path = "test.expt"
     refl_path = "test.refl"
-    dump.experiment_list(
-        generated_exp(number_of_experiments, assign_ids=True), exp_path
-    )
+    generated_exp(number_of_experiments, assign_ids=True).as_file(exp_path)
     reflections = flex.reflection_table()
     for i in range(number_of_experiments):
         reflections.extend(generate_test_refl(id_=i, assign_id=True))
@@ -259,7 +257,7 @@ def test_assign_and_return_datasets(helper):
         si = sweephandler.get_sweep_information(i)
         refl_path, exp_path = ("test_%s.refl" % i, "test_%s.expt" % i)
         generate_test_refl().as_pickle(refl_path)
-        dump.experiment_list(generated_exp(), exp_path)
+        generated_exp().as_file(exp_path)
         si.set_experiments(exp_path)
         si.set_reflections(refl_path)
     sweephandler = helper.assign_and_return_datasets(sweephandler)
@@ -379,7 +377,7 @@ def test_dials_symmetry_indexer_jiffy(helper, refiner_lattices, expected_output)
     for i in range(0, n):
         refl_path, exp_path = ("test_%s.refl" % i, "test_%s.expt" % i)
         generate_reflections_in_sg("P 2", id_=i, assign_id=True).as_pickle(refl_path)
-        dump.experiment_list(generated_exp(space_group="P 2", id_=i), exp_path)
+        generated_exp(space_group="P 2", id_=i).as_file(exp_path)
         experiments.append(exp_path)
         reflections.append(refl_path)
         refiners.append(simple_refiner(refiner_lattices))


### PR DESCRIPTION
While working in `DialsIndexer`, I noticed a deprecation warning, so I did a little semi-automatic tidy-up.  This PR does the following, based on the advice in the deprecation warnings:
* Replace `dxtbx.model.experiment_list.ExperimentListDumper` and `dxtbx.serialize.dump` with `as_file` method of experiment list;
* Remove `xia2.Applications.xia2setup.save_experiments`, which doesn't seem to be used anywhere;
* Remove some unused imports and variables to satisfy flake8.

Any objections?

There are corresponding PRs to follow in dials, dials_scratch & dxtbx.