### PR TITLE
Updates to avoid excessive calls to dials.export

### DIFF
--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -751,7 +751,7 @@ xia2.settings
       .type = float(value_min=0.0)
       .help = "High resolution cutoff."
       .short_caption = "High resolution cutoff"
-    include scope dials.util.Resolutionizer.phil_str
+    include scope dials.util.resolutionizer.phil_str
   }
   unify_setting = False
     .type = bool

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -38,7 +38,7 @@ class DialsIntegrater(Integrater):
         # check that the programs exist - this will raise an exception if
         # they do not...
 
-        integrate = xia2.Wrappers.Dials.Integrate.Integrate()
+        _ = xia2.Wrappers.Dials.Integrate.Integrate()
 
         # place to store working data
         self._data_files = {}
@@ -412,7 +412,7 @@ class DialsIntegrater(Integrater):
         try:
             m_min, m_max, m_mean = mosaic.min_max_mean().as_tuple()
             self.set_integrater_mosaic_min_mean_max(m_min, m_mean, m_max)
-        except AttributeError as e:
+        except AttributeError:
             self.set_integrater_mosaic_min_mean_max(mosaic, mosaic, mosaic)
 
         Chatter.write(

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -50,6 +50,9 @@ class DialsIntegrater(Integrater):
         self._intgr_integrated_reflections = None
         self._intgr_experiments_filename = None
 
+        if PhilIndex.params.xia2.settings.pipeline in ["dials", "dials-full"]:
+            self.set_output_format("pickle")
+
     # overload these methods as we don't want the resolution range
     # feeding back... aha - but we may want to assign them
     # from outside!

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -38,7 +38,7 @@ class DialsIntegrater(Integrater):
         # check that the programs exist - this will raise an exception if
         # they do not...
 
-        _ = xia2.Wrappers.Dials.Integrate.Integrate()
+        xia2.Wrappers.Dials.Integrate.Integrate()
 
         # place to store working data
         self._data_files = {}

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -96,7 +96,7 @@ resolution
     .type = float(value_min=0.0)
     .help = "High resolution cutoff."
     .short_caption = "High resolution cutoff"
-  include scope dials.util.Resolutionizer.phil_str
+  include scope dials.util.resolutionizer.phil_str
 }
 
 multi_crystal_analysis {

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -784,6 +784,17 @@ class Scale(object):
         auto_logfiler(scaler)
         scaler.add_experiments_json(self._experiments_filename)
         scaler.add_reflections_file(self._reflections_filename)
+
+        # need to set unmerged_mtz, merged_mtz in Scale wrapper
+        unmerged_mtz = os.path.join(
+            scaler.get_working_directory(), "%i_scaled_unmerged.mtz" % scaler.get_xpid()
+        )
+        merged_mtz = os.path.join(
+            scaler.get_working_directory(), "%i_scaled.mtz" % scaler.get_xpid()
+        )
+        scaler.set_scaled_unmerged_mtz(unmerged_mtz)
+        scaler.set_scaled_mtz(merged_mtz)
+
         lmax = self._params.scaling.secondary.lmax
         if lmax:
             scaler.set_absorption_correction(True)

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -841,7 +841,12 @@ class Scale(object):
         params = self._params.resolution
         m = Merger()
         auto_logfiler(m)
-        m.set_hklin(self._scaled_unmerged_mtz)
+        # use the scaled .refl and .expt file
+        if self._experiments_filename and self._reflections_filename:
+            m.set_reflections(self._reflections_filename)
+            m.set_experiments(self._experiments_filename)
+        else:
+            m.set_hklin(self._scaled_unmerged_mtz)
         m.set_limit_rmerge(params.rmerge)
         m.set_limit_completeness(params.completeness)
         m.set_limit_cc_half(params.cc_half)

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -303,8 +303,6 @@ class CommonScaler(Scaler):
             xname = self._sweep_information[epoch]["xname"]
             dname = self._sweep_information[epoch]["dname"]
 
-            sname = self._sweep_information[epoch]["sname"]
-
             hklout = os.path.join(
                 self.get_working_directory(),
                 "%s_%s_%s_%d.mtz" % (pname, xname, dname, counter),
@@ -1624,7 +1622,6 @@ def anomalous_probability_plot(intensities, expected_delta=None):
         y = y.select(sel)
 
     fit = flex.linear_regression(x, y)
-    correlation = flex.linear_correlation(x, y)
     assert fit.is_well_defined()
 
     if 0:

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -981,7 +981,13 @@ class CommonScaler(Scaler):
             Debug.write("Local scaling failed")
 
     def _estimate_resolution_limit(
-        self, hklin, batch_range=None, use_isigma=True, use_misigma=True
+        self,
+        hklin,
+        batch_range=None,
+        use_isigma=True,
+        use_misigma=True,
+        reflections=None,
+        experiments=None,
     ):
         params = PhilIndex.params.xia2.settings.resolution
         m = Merger()
@@ -989,7 +995,12 @@ class CommonScaler(Scaler):
         from xia2.lib.bits import auto_logfiler
 
         auto_logfiler(m)
-        m.set_hklin(hklin)
+        if hklin:
+            m.set_hklin(hklin)
+        else:
+            assert reflections and experiments
+            m.set_reflections(reflections)
+            m.set_experiments(experiments)
         m.set_limit_rmerge(params.rmerge)
         m.set_limit_completeness(params.completeness)
         m.set_limit_cc_half(params.cc_half)
@@ -1484,7 +1495,13 @@ class CommonScaler(Scaler):
                 )
 
     def assess_resolution_limits(
-        self, hklin, user_resolution_limits, use_isigma=True, use_misigma=True
+        self,
+        hklin,
+        user_resolution_limits,
+        use_isigma=True,
+        use_misigma=True,
+        experiments=None,
+        reflections=None,
     ):
         """Assess resolution limits from hklin and sweep batch info"""
         # Implemented for DialsScaler and CCP4ScalerA
@@ -1511,12 +1528,22 @@ class CommonScaler(Scaler):
                 )
                 continue
 
-            limit, reasoning = self._estimate_resolution_limit(
-                hklin,
-                batch_range=(start, end),
-                use_isigma=use_isigma,
-                use_misigma=use_misigma,
-            )
+            if hklin:
+                limit, reasoning = self._estimate_resolution_limit(
+                    hklin,
+                    batch_range=(start, end),
+                    use_isigma=use_isigma,
+                    use_misigma=use_misigma,
+                )
+            else:
+                limit, reasoning = self._estimate_resolution_limit(
+                    hklin=None,
+                    batch_range=(start, end),
+                    use_isigma=use_isigma,
+                    use_misigma=use_misigma,
+                    reflections=reflections,
+                    experiments=experiments,
+                )
 
             if PhilIndex.params.xia2.settings.resolution.keep_all_reflections:
                 suggested = limit

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -508,14 +508,6 @@ pipeline=dials (supported for pipeline=dials-aimless).
         self._scalr_scaled_reflection_files["mtz_unmerged"] = {}
         self._scalr_scaled_reflection_files["mtz"] = {}
 
-        # Set the unmerged mtz output filename - need for merging stats calc.
-        scaled_unmerged_mtz_path = os.path.join(
-            self.get_working_directory(),
-            "%s_%s_scaled_unmerged.mtz" % (self._scalr_pname, self._scalr_xname),
-        )
-        self._scaler.set_scaled_unmerged_mtz(scaled_unmerged_mtz_path)
-        self._scaler.set_crystal_name(self._scalr_xname)  # Name goes in mtz
-
         ### Set the resolution limit if applicable
 
         user_resolution_limits = {}
@@ -556,8 +548,6 @@ pipeline=dials (supported for pipeline=dials-aimless).
         )
         self._scaled_experiments = self._scaler.get_scaled_experiments()
         self._scaled_reflections = self._scaler.get_scaled_reflections()
-
-        FileHandler.record_data_file(scaled_unmerged_mtz_path)
 
         # make it so that only scaled.expt and scaled.refl are
         # the files that dials.scale knows about, so that if scale is called again,
@@ -625,6 +615,11 @@ pipeline=dials (supported for pipeline=dials-aimless).
                 si.get_project_info()[2]
             )  # sweep info in same order as experiments
         assert len(wavelengths) == len(dnames_set)
+
+        scaled_unmerged_mtz_path = os.path.join(
+            self.get_working_directory(),
+            "%s_%s_scaled_unmerged.mtz" % (self._scalr_pname, self._scalr_xname),
+        )
 
         if len(dnames_set) > 1:
             self._scalr_scaled_refl_files = {}

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -557,7 +557,7 @@ pipeline=dials (supported for pipeline=dials-aimless).
         ### Calculate the resolution limit and set done False if applicable
 
         highest_suggested_resolution = self.assess_resolution_limits(
-            hklin=None,  # self._scaler.get_unmerged_reflection_file(),
+            hklin=None,
             user_resolution_limits=user_resolution_limits,
             use_misigma=False,
             reflections=self._scaled_reflections,

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -567,9 +567,11 @@ pipeline=dials (supported for pipeline=dials-aimless).
         ### Calculate the resolution limit and set done False if applicable
 
         highest_suggested_resolution = self.assess_resolution_limits(
-            self._scaler.get_unmerged_reflection_file(),
-            user_resolution_limits,
+            hklin=None,  # self._scaler.get_unmerged_reflection_file(),
+            user_resolution_limits=user_resolution_limits,
             use_misigma=False,
+            reflections=self._scaled_reflections,
+            experiments=self._scaled_experiments,
         )
 
         if not self.get_scaler_done():

--- a/Wrappers/Dials/Scale.py
+++ b/Wrappers/Dials/Scale.py
@@ -307,18 +307,13 @@ def DialsScale(DriverType=None, decay_correction=None):
                 self._scaled_reflections = os.path.join(
                     self.get_working_directory(), "%i_scaled.refl" % self.get_xpid()
                 )
-            if not self._unmerged_reflections:
-                self._unmerged_reflections = os.path.join(
-                    self.get_working_directory(),
-                    "%i_scaled_unmerged.mtz" % self.get_xpid(),
+            if self._unmerged_reflections:
+                self.add_command_line(
+                    "output.unmerged_mtz=%s" % self._unmerged_reflections
                 )
-            self.add_command_line("output.unmerged_mtz=%s" % self._unmerged_reflections)
 
-            if not self._merged_reflections:
-                self._merged_reflections = os.path.join(
-                    self.get_working_directory(), "%i_scaled.mtz" % self.get_xpid()
-                )
-            self.add_command_line("output.merged_mtz=%s" % self._merged_reflections)
+            if self._merged_reflections:
+                self.add_command_line("output.merged_mtz=%s" % self._merged_reflections)
 
             if not self._html:
                 self._html = os.path.join(

--- a/Wrappers/XIA/Merger.py
+++ b/Wrappers/XIA/Merger.py
@@ -14,10 +14,12 @@ def Merger(DriverType=None):
     class MergerWrapper(DriverInstance.__class__):
         def __init__(self):
             DriverInstance.__class__.__init__(self)
-            self.set_executable("xia2.resolutionizer")
+            self.set_executable("dials.resolutionizer")
 
             # inputs
             self._hklin = None
+            self._reflections = None
+            self._experiments = None
             self._limit_rmerge = None
             self._limit_completeness = None
             self._limit_cc_half = None
@@ -35,6 +37,12 @@ def Merger(DriverType=None):
             self._resolution_cc_half = None
             self._resolution_isigma = None
             self._resolution_misigma = None
+
+        def set_reflections(self, filename):
+            self._reflections = filename
+
+        def set_experiments(self, filename):
+            self._experiments = filename
 
         def set_hklin(self, hklin):
             self._hklin = hklin
@@ -85,8 +93,11 @@ def Merger(DriverType=None):
             return self._resolution_misigma
 
         def run(self):
-            assert self._hklin
-            cl = [self._hklin]
+            assert self._hklin or (self._experiments and self._reflections)
+            if self._hklin:
+                cl = [self._hklin]
+            else:
+                cl = [self._experiments, self._reflections]
             cl.append("nbins=%s" % self._nbins)
             cl.append("rmerge=%s" % self._limit_rmerge)
             cl.append("completeness=%s" % self._limit_completeness)

--- a/command_line/resolutionizer.py
+++ b/command_line/resolutionizer.py
@@ -1,9 +1,0 @@
-# LIBTBX_PRE_DISPATCHER_INCLUDE_SH export BOOST_ADAPTBX_FPE_DEFAULT=1
-from __future__ import absolute_import, division, print_function
-
-import sys
-
-if __name__ == "__main__":
-    from dials.util.Resolutionizer import run
-
-    run(sys.argv[1:])

--- a/newsfragments/329.feature
+++ b/newsfragments/329.feature
@@ -1,0 +1,4 @@
+Reduce the number of calls to dials.export for performance improvement.
+
+The integrated.mtz (unscaled) no longer appears in the Logfiles but can
+be generated from the corresponding .refl and .expt files


### PR DESCRIPTION
Update calls to resolutionizer to match new dials code - use native .refl and .expt files.

Don't export mtz by default in dials.scale as not necessary.

When constructing DialsIntegrater, set option to not export mtz files if dials-full (==dials) pipeline as not needed for subsequent processes.