### PR TITLE
Introduce persistent DIALS indexer

### DIFF
--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -877,7 +877,7 @@ class PersistentDialsIndexer(DialsIndexer):
             try:
                 Chatter.write(
                     "Retrying indexing, now with a maximum unit cell basis vector "
-                    u"length of 20 Å."
+                    "length of 20 Angstrom."
                 )
                 PhilIndex.params.dials.index.max_cell = 20
                 return super(PersistentDialsIndexer, self)._index()
@@ -892,7 +892,7 @@ class PersistentDialsIndexer(DialsIndexer):
             Chatter.write(
                 "Retrying spotfinding, now only recognising pixels as belonging to "
                 "reflections if their intensity is greater than the local mean "
-                u"by more than more than 15× the standard deviation."
+                "by more than more than 15 times the standard deviation."
             )
             # Reset the max_cell parameter to its original value.
             PhilIndex.params.dials.index.max_cell = max_cell

--- a/Modules/Indexer/IndexerFactory.py
+++ b/Modules/Indexer/IndexerFactory.py
@@ -35,7 +35,7 @@ from xia2.DriverExceptions.NotAvailableError import NotAvailableError
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.PipelineSelection import get_preferences
 from xia2.Handlers.Streams import Debug
-from xia2.Modules.Indexer.DialsIndexer import DialsIndexer
+from xia2.Modules.Indexer.DialsIndexer import DialsIndexer, PersistentDialsIndexer
 from xia2.Modules.Indexer.LabelitIndexer import LabelitIndexer
 from xia2.Modules.Indexer.LabelitIndexerII import LabelitIndexerII
 from xia2.Modules.Indexer.MosflmIndexer import MosflmIndexer
@@ -174,6 +174,13 @@ def Indexer(preselection=None):
         (MosflmIndexer, "mosflm", "Mosflm Indexer"),
         (XDSIndexer, "xds", "XDS Indexer"),
     ]
+
+    # Only use the persistent DIALS indexer in small molecule mode,
+    # where it should be the default.
+    if PhilIndex.params.xia2.settings.small_molecule:
+        indexerlist.insert(
+            0, (PersistentDialsIndexer, "dials", "PersistentDialsIndexer")
+        )
 
     if PhilIndex.params.xia2.settings.interactive:
         indexerlist.append((XDSIndexerInteractive, "xdsii", "XDS Interactive Indexer"))

--- a/Test/Modules/Indexer/test_DIALS_indexer.py
+++ b/Test/Modules/Indexer/test_DIALS_indexer.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import pytest
 import sys
 
 import mock
@@ -71,6 +72,54 @@ def exercise_dials_indexer(dials_data, tmp_dir, nproc=None):
     assert approx_equal(indexer.get_indexer_cell(), indexer2.get_indexer_cell())
     assert indexer.get_indexer_lattice() == "hR"
     assert indexer2.get_indexer_lattice() == "hR"
+
+
+@pytest.mark.skip(reason="Test data currently embargoed, see DLS Jira SCI-8133.")
+def test_persistent_dials_indexer(dials_data, tmp_dir, nproc=None):
+    if nproc is not None:
+        from xia2.Handlers.Phil import PhilIndex
+
+        PhilIndex.params.xia2.settings.multiprocessing.nproc = nproc
+
+    template = dials_data("insulin").join("insulin_1_###.img").strpath  # FIXME
+
+    from xia2.Modules.Indexer.DialsIndexer import PersistentDialsIndexer
+
+    indexer = PersistentDialsIndexer()
+    indexer.set_working_directory(tmp_dir)
+    from dxtbx.model.experiment_list import ExperimentListTemplateImporter
+
+    importer = ExperimentListTemplateImporter([template])
+    experiments = importer.experiments
+    imageset = experiments.imagesets()[0]
+    indexer.add_indexer_imageset(imageset)
+
+    from xia2.Schema.XCrystal import XCrystal
+    from xia2.Schema.XWavelength import XWavelength
+    from xia2.Schema.XSweep import XSweep
+    from xia2.Schema.XSample import XSample
+
+    cryst = XCrystal("CRYST1", None)
+    wav = XWavelength("WAVE1", cryst, imageset.get_beam().get_wavelength())
+    samp = XSample("X1", cryst)
+    directory, image = os.path.split(imageset.get_path(1))
+    sweep = XSweep("SWEEP1", wav, samp, directory=directory, image=image)
+    indexer.set_indexer_sweep(sweep)
+
+    indexer.index()
+
+    # FIXME:  Tidy up the assertions according to the real test data.
+    assert approx_equal(
+        indexer.get_indexer_cell(), (78.14, 78.14, 78.14, 90, 90, 90), eps=1e-1
+    )
+    solution = indexer.get_solution()
+    assert approx_equal(solution["rmsd"], 0.041, eps=1e-2)
+    assert approx_equal(solution["metric"], 0.027, eps=1e-2)
+    assert solution["number"] == 22
+    assert solution["lattice"] == "cI"
+
+    beam_centre = indexer.get_indexer_beam_centre()
+    assert approx_equal(beam_centre, (94.4223, 94.5097), eps=1e-2)
 
 
 def test_dials_indexer_serial(regression_test, ccp4, dials_data, run_in_tmpdir):

--- a/newsfragments/331.feature
+++ b/newsfragments/331.feature
@@ -1,7 +1,7 @@
 xia2 with DIALS is now more persistent in searching for an indexing
 solution when using xia2 in small molecule mode (i.e. when calling
 ``xia2.small_molecule`` or when calling ``xia2`` with the option
-``small_molecule=True``).  Previously, it would perform a 3-d fast
+``small_molecule=True``).  Previously, it would perform a 3D fast
 Fourier transform, falling back on a 1-d FFT strategy.  It now performs
 the following indexing strategies in turn until a result is found:
   1. Try the standard 3-d/1-d FFT indexing routine;

--- a/newsfragments/331.feature
+++ b/newsfragments/331.feature
@@ -4,7 +4,7 @@ solution when using xia2 in small molecule mode (i.e. when calling
 ``small_molecule=True``).  Previously, it would perform a 3D fast
 Fourier transform, falling back on a 1-d FFT strategy.  It now performs
 the following indexing strategies in turn until a result is found:
-  1. Try the standard 3-d/1-d FFT indexing routine;
+  1. Try the standard 3D/1D FFT indexing routine;
   2. Do 1 again with the addition of the option
      ``dials.index.max_cell=20``;
   3. Repeat spot finding with the addition of the option

--- a/newsfragments/331.feature
+++ b/newsfragments/331.feature
@@ -1,0 +1,11 @@
+xia2 with DIALS is now more persistent in searching for an indexing
+solution when using xia2 in small molecule mode (i.e. when calling
+``xia2.small_molecule`` or when calling ``xia2`` with the option
+``small_molecule=True``).  Previously, it would perform a 3-d fast
+Fourier transform, falling back on a 1-d FFT strategy.  It now performs
+the following indexing strategies in turn until a result is found:
+  1. Try the standard 3-d/1-d FFT indexing routine;
+  2. Do 1 again with the addition of the option
+     ``dials.index.max_cell=20``;
+  3. Repeat spot finding with the addition of the option
+     ``dials.find_spots.sigma_strong=15``, then do 1 & 2 again.


### PR DESCRIPTION
Emulate the indexing behaviour of screen19 when `small_molecule=True`
and `pipeline=dials`, as requested by users of beamline I19 at Diamond Light Source.

This introduces a new indexer, a sub-class of `xia2.Modules.Indexer.DialsIndexer`, which performs the following:
- It sets the parameter `dials.index.method=auto`, meaning that if no suggested indexing solution is provided, the data will be indexed with both a 3-d and a 1-d fast Fourier transform, with the best solution retained.
- If the data don't index on the first pass, the parameter `dials.index.max_cell=20` is used to eliminate potentially spurious super-cells and the indexing is attempted again.  This step is skipped if the user has already specified a maximum lattice parameter equal to or less than 20 Å.
- If the data still don't index, spot finding is repeated, this time using the parameter `dials.find_spots.sigma_strong=15`.  The above two strategies are then repeated.  This step is skipped if the user has already used a σ_strong value equal to or greater than 15σ.

The new indexer is used as the default when in `small_molecule` mode.  It is not used otherwise.

No new tests have been introduced because suitable test data is currently embargoed.