### PR TITLE
Update command line tool log streaming interface

### DIFF
--- a/command_line/check_mosaic.py
+++ b/command_line/check_mosaic.py
@@ -1,6 +1,7 @@
 # LIBTBX_SET_DISPATCHER_NAME dev.xia2.check_mosaic
 from __future__ import absolute_import, division, print_function
 
+import sys
 import six.moves.cPickle as pickle
 
 from dials.array_family import flex
@@ -52,6 +53,4 @@ def go(filename):
 
 
 if __name__ == "__main__":
-    import sys
-
     go(sys.argv[1])

--- a/command_line/chef.py
+++ b/command_line/chef.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 
-if __name__ == "__main__":
-    from dials.pychef import run
+from dials.pychef import run
 
+
+if __name__ == "__main__":
     run(sys.argv[1:])

--- a/command_line/create_mask.py
+++ b/command_line/create_mask.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 
+import six.moves.cPickle as pickle
+from dxtbx import load
+
 
 def main(filename, threshold, images):
     """Read and sum all images, define those pixels which are POSITIVE but which
     come out below threshold as mask, write this mask in a format useful for
     DIALS."""
-
-    from dxtbx import load
-    import six.moves.cPickle as pickle
 
     image_data = None
 

--- a/command_line/delta_cc_half.py
+++ b/command_line/delta_cc_half.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 
-if __name__ == "__main__":
-    from xia2.Modules.DeltaCcHalf import run
+import xia2.Handlers.Streams
+from xia2.Modules.DeltaCcHalf import run
 
+if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging()
     run(sys.argv[1:])

--- a/command_line/html.py
+++ b/command_line/html.py
@@ -17,6 +17,7 @@ import xia2
 from xia2.Modules.Report import Report
 from xia2.Handlers.Citations import Citations
 from xia2.Handlers.Streams import Chatter, Debug
+import xia2.Handlers.Streams
 
 
 def run(args):
@@ -585,4 +586,6 @@ tick: {
 
 if __name__ == "__main__":
     args = sys.argv[1:]
+    xia2.Handlers.Streams.setup_logging(logfile="xia2.html.log")
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     run(args)

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -5,6 +5,7 @@ import sys
 import traceback
 
 from xia2.Applications.xia2_main import check_environment, help
+import xia2.Handlers.Streams
 from xia2.Handlers.Streams import Chatter
 
 
@@ -36,4 +37,8 @@ def run():
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.index.txt", debugfile="xia2.index-debug.txt"
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     run()

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -5,6 +5,7 @@ import sys
 import traceback
 
 from xia2.Applications.xia2_main import check_environment, help
+import xia2.Handlers.Streams
 from xia2.Handlers.Streams import Chatter
 
 
@@ -37,4 +38,8 @@ def run():
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.integrate.txt", debugfile="xia2.integrate-debug.txt"
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     run()

--- a/command_line/ispyb_json.py
+++ b/command_line/ispyb_json.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 
+import xia2.Handlers.Streams
 import xia2.Interfaces.ISPyB
 from xia2.Schema.XProject import XProject
 
@@ -39,6 +40,8 @@ def ispyb_json(json_out):
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging()
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     if len(sys.argv) >= 2:
         ispyb_json(sys.argv[1])
     else:

--- a/command_line/ispyb_xml.py
+++ b/command_line/ispyb_xml.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import sys
+
 import iotbx.phil
+import xia2.Handlers.Streams
 from xia2.Interfaces.ISPyB.ISPyBXmlHandler import ISPyBXmlHandler
 from xia2.Schema.XProject import XProject
 
@@ -25,8 +28,8 @@ def ispyb_xml(xml_out):
 
 
 if __name__ == "__main__":
-    import sys
-
+    xia2.Handlers.Streams.setup_logging()
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     if len(sys.argv) >= 2:
         ispyb_xml(sys.argv[1])
     else:

--- a/command_line/multi_crystal_analysis.py
+++ b/command_line/multi_crystal_analysis.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-#!/usr/bin/env xia2.python
 from __future__ import absolute_import, division, print_function
 
 import logging
@@ -14,6 +13,7 @@ from dials.util.options import OptionParser
 from dials.util.options import flatten_experiments, flatten_reflections
 from dials.util.version import dials_version
 from dials.util.multi_dataset_handling import parse_multiple_datasets
+import xia2.Handlers.Streams
 from xia2.Modules.MultiCrystalAnalysis import MultiCrystalReport
 
 logger = logging.getLogger("xia2.multi_crystal_analysis")
@@ -126,4 +126,9 @@ def run():
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.multi_crystal_analysis.txt",
+        debugfile="xia2.multi_crystal_analysis-debug.txt",
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     run()

--- a/command_line/multiplex.py
+++ b/command_line/multiplex.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env dials.python
 from __future__ import absolute_import, division, print_function
 
 import logging
@@ -60,10 +59,10 @@ def run(args):
     params, options = parser.parse_args(args=args, show_diff_phil=False)
 
     # Configure the logging
-    xia2.Handlers.Streams.streams_off()
     xia2.Handlers.Streams.setup_logging(
         logfile=params.output.log, verbose=options.verbose
     )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
 
     logger.info(dials_version())
 

--- a/command_line/npp.py
+++ b/command_line/npp.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import math
 import sys
 
+import xia2.Handlers.Streams
 from iotbx.reflection_file_reader import any_reflection_file
 from scitbx.array_family import flex
 
@@ -69,4 +70,8 @@ def npp(hklin):
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.npp.txt", debugfile="xia2.npp-debug.txt"
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     npp(sys.argv[1])

--- a/command_line/print.py
+++ b/command_line/print.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from xia2.Applications.xia2_main import write_citations
+import xia2.Handlers.Streams
 from xia2.Handlers.Streams import Chatter
 
 
@@ -16,4 +17,8 @@ def run():
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.print.txt", debugfile="xia2.print-debug.txt"
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     run()

--- a/command_line/rebatch.py
+++ b/command_line/rebatch.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
+import xia2.Handlers.Streams
+
 master_phil = """\
 hklin = None
   .type = path
@@ -47,6 +50,8 @@ def run(args):
 
 
 if __name__ == "__main__":
-    import sys
-
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.rebatch.txt", debugfile="xia2.rebatch-debug.txt"
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     run(sys.argv[1:])

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 import iotbx.phil
 from dials.util.options import OptionParser
 from jinja2 import Environment, ChoiceLoader, PackageLoader
+import xia2.Handlers.Streams
 from xia2.Modules.Report import Report
 
 phil_scope = iotbx.phil.parse(
@@ -158,4 +159,8 @@ def run(args):
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.report.txt", debugfile="xia2.report-debug.txt"
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     run(sys.argv[1:])

--- a/command_line/rescale.py
+++ b/command_line/rescale.py
@@ -6,7 +6,7 @@ import time
 import traceback
 
 from libtbx import Auto
-
+import xia2.Handlers.Streams
 from xia2.Applications.xia2_main import check_environment, write_citations
 from xia2.Handlers.Citations import Citations
 from xia2.Handlers.Environment import Environment
@@ -73,4 +73,8 @@ def run():
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.rescale.txt", debugfile="xia2.rescale-debug.txt"
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     run()

--- a/command_line/rogues_gallery.py
+++ b/command_line/rogues_gallery.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import six.moves.cPickle as pickle
+import xia2.Handlers.Streams
 from dials.array_family import flex
 
 
@@ -128,6 +129,10 @@ def reconstruct_rogues(params):
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.rogues_gallery.txt", debugfile="xia2.rogues_gallery-debug.txt"
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     from libtbx.phil import parse
 
     phil_scope = parse(

--- a/command_line/show_mask.py
+++ b/command_line/show_mask.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import six.moves.cPickle as pickle
-from dials.array_family import flex  # noqa # lgtm # Required for pickle loading
+from dials.array_family import flex  # lgtm # noqa # Required for pickle loading
 
 
 def main(filename):

--- a/command_line/show_mask.py
+++ b/command_line/show_mask.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import six.moves.cPickle as pickle
-from dials.array_family import flex  # noqa; lgtm; Required for pickle loading
+from dials.array_family import flex  # noqa; lgtm - Required for pickle loading
 
 
 def main(filename):

--- a/command_line/show_mask.py
+++ b/command_line/show_mask.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import six.moves.cPickle as pickle
-from dials.array_family import flex  # lgtm # noqa # Required for pickle loading
+
+# import required for pickle loading
+from dials.array_family import flex  # noqa
 
 
 def main(filename):

--- a/command_line/show_mask.py
+++ b/command_line/show_mask.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import six.moves.cPickle as pickle
-from dials.array_family import flex  # noqa; lgtm - Required for pickle loading
+from dials.array_family import flex  # noqa # lgtm # Required for pickle loading
 
 
 def main(filename):

--- a/command_line/show_mask.py
+++ b/command_line/show_mask.py
@@ -2,13 +2,13 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
+import six.moves.cPickle as pickle
+from dials.array_family import flex  # noqa: F401; Required for pickle loading
 
 
 def main(filename):
     """Show a mask from create_mask."""
 
-    from dials.array_family import flex  # noqa: F401; Required for pickle loading
-    import six.moves.cPickle as pickle
     from matplotlib import pylab
 
     with open(filename, "rb") as fh:

--- a/command_line/show_mask.py
+++ b/command_line/show_mask.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import six.moves.cPickle as pickle
-from dials.array_family import flex  # noqa: F401; Required for pickle loading
+from dials.array_family import flex  # noqa; lgtm; Required for pickle loading
 
 
 def main(filename):

--- a/command_line/show_mask.py
+++ b/command_line/show_mask.py
@@ -4,8 +4,7 @@ from __future__ import absolute_import, division, print_function
 import sys
 import six.moves.cPickle as pickle
 
-# import required for pickle loading
-from dials.array_family import flex  # noqa
+from dials.array_family import flex  # noqa; lgtm; required for pickle loading
 
 
 def main(filename):

--- a/command_line/strategy.py
+++ b/command_line/strategy.py
@@ -1,6 +1,3 @@
-# LIBTBX_SET_DISPATCHER_NAME dev.xia2.strategy
-# LIBTBX_SET_DISPATCHER_NAME xia2.strategy
-
 from __future__ import absolute_import, division, print_function
 
 import json
@@ -9,6 +6,7 @@ import sys
 import traceback
 
 from xia2.Applications.xia2_main import check_environment, get_command_line, help
+import xia2.Handlers.Streams
 from xia2.Handlers.Streams import Chatter
 from xia2.lib.bits import auto_logfiler
 
@@ -209,4 +207,8 @@ def run():
 
 
 if __name__ == "__main__":
+    xia2.Handlers.Streams.setup_logging(
+        logfile="xia2.strategy.txt", debugfile="xia2.strategy-debug.txt"
+    )
+    xia2.Handlers.Streams.reconfigure_streams_to_logging()
     run()

--- a/command_line/table1.py
+++ b/command_line/table1.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_imports, division, print_function
+from __future__ import absolute_import, division, print_function
 
 import json
 import os

--- a/command_line/table1.py
+++ b/command_line/table1.py
@@ -1,4 +1,9 @@
-from __future__ import division, print_function
+from __future__ import absolute_imports, division, print_function
+
+import json
+import os
+import sys
+from cctbx import sgtbx
 
 
 def table1_tex(crystal_params, merging_stats):
@@ -31,8 +36,6 @@ def table1_tex(crystal_params, merging_stats):
     )
 
     # witchcraft to work out how to write out the unit cell
-    from cctbx import sgtbx
-
     cell_str = ["Unit-cell parameters (\\AA)"]
     for cp in crystal_params:
         sgi = sgtbx.space_group_info(str(cp["space_group"]))
@@ -111,10 +114,6 @@ def table1_tex(crystal_params, merging_stats):
 
 
 def table1():
-    import sys
-    import os
-    import json
-
     jsons = []
     for xia2 in sys.argv[1:]:
         assert os.path.exists(os.path.join(xia2, "xia2.json")), xia2

--- a/newsfragments/370.misc
+++ b/newsfragments/370.misc
@@ -1,0 +1,1 @@
+xia2 command line tools now configure log file output explicitly


### PR DESCRIPTION
Update all command line tools that import xia2 components to explicitly
create named log files and redirect all `Chatter()` and other stream
output to said log files.

Some commands that do not import from xia2 were not touched.

This is the first half of the first step of the list in #267