### PR TITLE
Use cc_half only by default for resolution cutoff

### DIFF
--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -11,10 +11,10 @@
 
 from __future__ import absolute_import, division, print_function
 
-from iotbx.phil import parse
+import iotbx.phil
 from libtbx.phil import interface
 
-master_phil = parse(
+master_phil = iotbx.phil.parse(
     """
 general
   .short_caption = "General settings"
@@ -938,6 +938,19 @@ xia2.settings
 """,
     process_includes=True,
 )
+
+# override default refinement parameters
+master_phil = master_phil.fetch(
+    source=iotbx.phil.parse(
+        """\
+xia2.settings.resolution {
+  isigma = None
+  misigma = None
+}
+"""
+    )
+)
+
 
 PhilIndex = interface.index(master_phil=master_phil)
 

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -965,13 +965,7 @@ class CommonScaler(Scaler):
             Debug.write("Local scaling failed")
 
     def _estimate_resolution_limit(
-        self,
-        hklin,
-        batch_range=None,
-        use_isigma=True,
-        use_misigma=True,
-        reflections=None,
-        experiments=None,
+        self, hklin, batch_range=None, reflections=None, experiments=None
     ):
         params = PhilIndex.params.xia2.settings.resolution
         m = Merger()
@@ -990,10 +984,8 @@ class CommonScaler(Scaler):
         m.set_limit_cc_half(params.cc_half)
         m.set_cc_half_fit(params.cc_half_fit)
         m.set_cc_half_significance_level(params.cc_half_significance_level)
-        if use_isigma:
-            m.set_limit_isigma(params.isigma)
-        if use_misigma:
-            m.set_limit_misigma(params.misigma)
+        m.set_limit_isigma(params.isigma)
+        m.set_limit_misigma(params.misigma)
         if PhilIndex.params.xia2.settings.small_molecule:
             m.set_nbins(20)
         if batch_range is not None:
@@ -1466,13 +1458,7 @@ class CommonScaler(Scaler):
                 )
 
     def assess_resolution_limits(
-        self,
-        hklin,
-        user_resolution_limits,
-        use_isigma=True,
-        use_misigma=True,
-        experiments=None,
-        reflections=None,
+        self, hklin, user_resolution_limits, experiments=None, reflections=None
     ):
         """Assess resolution limits from hklin and sweep batch info"""
         # Implemented for DialsScaler and CCP4ScalerA
@@ -1501,17 +1487,12 @@ class CommonScaler(Scaler):
 
             if hklin:
                 limit, reasoning = self._estimate_resolution_limit(
-                    hklin,
-                    batch_range=(start, end),
-                    use_isigma=use_isigma,
-                    use_misigma=use_misigma,
+                    hklin, batch_range=(start, end)
                 )
             else:
                 limit, reasoning = self._estimate_resolution_limit(
                     hklin=None,
                     batch_range=(start, end),
-                    use_isigma=use_isigma,
-                    use_misigma=use_misigma,
                     reflections=reflections,
                     experiments=experiments,
                 )

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -581,7 +581,6 @@ pipeline=dials (supported for pipeline=dials-aimless).
         highest_suggested_resolution = self.assess_resolution_limits(
             hklin=None,
             user_resolution_limits=user_resolution_limits,
-            use_misigma=False,
             reflections=self._scaled_reflections,
             experiments=self._scaled_experiments,
         )


### PR DESCRIPTION
Override default dials.resolutionizer parameters in xia2 phil.
Remove use_isigma, use_misigma parameters as no longer needed.

Alternative to #374

```
$ xia2 pipeline=dials trust_beam_centre=True read_all_image_headers=False $(dials.data get -q x4wide)
...
Resolution for sweep NATIVE/SWEEP1: 1.09 (cc_half > 0.3)
$ grep  Resolution DEFAULT/scale/*_dials.resolutionizer.log
Resolution cc_half:      1.09
```

```
$ xia2 pipeline=dials trust_beam_centre=True read_all_image_headers=False $(dials.data get -q x4wide) isigma=1 misigma=3
...
Resolution for sweep NATIVE/SWEEP1: 1.52 (merged <I/sigI> > 3.0)
$ grep  Resolution DEFAULT/scale/*_dials.resolutionizer.log
Resolution cc_half:      1.09
Resolution I/sig:        1.47
Resolution Mn(I/sig):    1.52
```