### PR TITLE
DIALS 2.0.2

### DIFF
--- a/Modules/Indexer/XDSIndexer.py
+++ b/Modules/Indexer/XDSIndexer.py
@@ -665,6 +665,13 @@ class XDSIndexer(IndexerSingleSweep):
 
         from dxtbx.model import Experiment, ExperimentList
 
+        # this information gets lost when re-creating the models from the
+        # XDS results - however is not refined so can simply copy from the
+        # input - https://github.com/xia2/xia2/issues/372
+        models.get_detector()[0].set_thickness(
+            converter.get_detector()[0].get_thickness()
+        )
+
         experiment = Experiment(
             beam=models.get_beam(),
             detector=models.get_detector(),

--- a/Modules/Indexer/XDSIndexerII.py
+++ b/Modules/Indexer/XDSIndexerII.py
@@ -303,6 +303,13 @@ class XDSIndexerII(XDSIndexer):
 
         from dxtbx.model import Experiment, ExperimentList
 
+        # this information gets lost when re-creating the models from the
+        # XDS results - however is not refined so can simply copy from the
+        # input - https://github.com/xia2/xia2/issues/372
+        models.get_detector()[0].set_thickness(
+            converter.get_detector()[0].get_thickness()
+        )
+
         experiment = Experiment(
             beam=models.get_beam(),
             detector=models.get_detector(),

--- a/Modules/Integrater/IntegraterFactory.py
+++ b/Modules/Integrater/IntegraterFactory.py
@@ -118,7 +118,7 @@ def Integrater():
         try:
             integrater = DialsIntegrater()
             Debug.write("Using Dials Integrater")
-            if PhilIndex.params.xia2.settings.pipeline in ["dials", "dials-full"]:
+            if PhilIndex.params.xia2.settings.scaler == "dials":
                 integrater.set_output_format("pickle")
         except NotAvailableError:
             if preselection == "dials":

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -474,7 +474,6 @@ class MultiCrystalScale(object):
         d.update(report.batch_dependent_plots())
         d.update(report.intensity_stats_plots())
         d.update(report.pychef_plots())
-        d.update(report.pychef_plots(n_bins=1))
 
         max_points = 500
         for g in (

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -81,8 +81,14 @@ symmetry {
   }
   le_page_max_delta = 5
     .type = float(value_min=0)
+  laue_group = None
+    .type = space_group
+    .help = "Specify the Laue group. If None, then the Laue group will be determined "
+            "by dials.cosym."
   space_group = None
     .type = space_group
+    .help = "Specify the space group. If None, then the dials.symmetry will perform "
+            "analysis of systematically absent reflections to determine the space group."
 }
 
 resolution
@@ -304,6 +310,8 @@ class MultiCrystalScale(object):
         self._data_manager = DataManager(experiments, reflections)
 
         self._params = params
+        if all([params.symmetry.laue_group, params.symmetry.space_group]):
+            raise ValueError("Can not specify both laue_group and space_group")
 
         if self._params.nproc is Auto:
             self._params.nproc = get_number_cpus()
@@ -365,13 +373,13 @@ class MultiCrystalScale(object):
         if self._params.symmetry.resolve_indexing_ambiguity:
             self.cosym()
 
-        self.decide_space_group()
-
         self._individual_report_dicts = OrderedDict()
         self._comparison_graphs = OrderedDict()
 
         self._scaled = Scale(self._data_manager, self._params)
         self._record_individual_report(self._scaled.report(), "All data")
+
+        self.decide_space_group()
 
         self._data_manager.export_experiments("multiplex.expt")
         self._data_manager.export_reflections("multiplex.refl")
@@ -604,6 +612,8 @@ class MultiCrystalScale(object):
         cosym.add_reflections_file(reflections_filename)
         if self._params.symmetry.space_group is not None:
             cosym.set_space_group(self._params.symmetry.space_group.group())
+        if self._params.symmetry.laue_group is not None:
+            cosym.set_space_group(self._params.symmetry.laue_group.group())
         cosym.run()
         self._cosym_analysis = cosym.get_cosym_analysis()
         self._experiments_filename = cosym.get_reindexed_experiments()
@@ -615,14 +625,16 @@ class MultiCrystalScale(object):
             self._reflections_filename
         )
 
-        if self._params.symmetry.space_group is None:
+        if not any(
+            [self._params.symmetry.space_group, self._params.symmetry.laue_group]
+        ):
             best_solution = cosym.get_best_solution()
             best_space_group = sgtbx.space_group(
                 str(best_solution["patterson_group"])
             ).build_derived_acentric_group()
-            self._params.symmetry.space_group = best_space_group.info()
+            self._params.symmetry.laue_group = best_space_group.info()
             logger.info(
-                "Space group determined by dials.cosym: %s" % best_space_group.info()
+                "Laue group determined by dials.cosym: %s" % best_space_group.info()
             )
 
         return
@@ -664,10 +676,8 @@ class MultiCrystalScale(object):
         symmetry.set_tolerance(
             relative_length_tolerance=None, absolute_angle_tolerance=None
         )
+        symmetry.set_mode_absences_only()
         symmetry.decide_pointgroup()
-        space_group = sgtbx.space_group_info(
-            symbol=str(symmetry.get_pointgroup())
-        ).group()
 
         self._data_manager.experiments = load.experiment_list(
             self._experiments_filename, check_format=False
@@ -675,6 +685,7 @@ class MultiCrystalScale(object):
         self._data_manager.reflections = flex.reflection_table.from_file(
             self._reflections_filename
         )
+        space_group = self._data_manager.experiments[0].crystal.get_space_group()
 
         logger.info("Space group determined by dials.symmetry: %s" % space_group.info())
 

--- a/Modules/Report/__init__.py
+++ b/Modules/Report/__init__.py
@@ -14,7 +14,7 @@ from iotbx import merging_statistics
 from iotbx.reflection_file_reader import any_reflection_file
 from mmtbx.scaling import printed_output
 
-from dials.util.batch_handling import batch_manager
+from dials.pychef import dose_phil_str
 from dials.report.analysis import batch_dependent_properties
 from dials.report.plots import (
     i_over_sig_i_vs_batch_plot,
@@ -22,6 +22,7 @@ from dials.report.plots import (
     ResolutionPlotsAndStats,
     IntensityStatisticsPlots,
 )
+from dials.util.batch_handling import batch_manager
 
 from xia2.Modules.Analysis import batch_phil_scope, phil_scope, separate_unmerged
 
@@ -334,11 +335,17 @@ class Report(object):
 
         params.batch = []
         scope = libtbx.phil.parse(batch_phil_scope)
+        dose_phil = libtbx.phil.parse(dose_phil_str).extract()
         for expt in data_manager.experiments:
             batch_params = scope.extract().batch[0]
             batch_params.id = expt.identifier
             batch_params.range = expt.scan.get_batch_range()
             params.batch.append(batch_params)
+            dose_batch = copy.deepcopy(dose_phil.dose.batch[0])
+            dose_batch.range = expt.scan.get_batch_range()
+            dose_batch.dose_start = 1
+            dose_batch.dose_step = 1
+            params.dose.batch.append(dose_batch)
 
         intensities.set_observation_type_xray_intensity()
         return cls(intensities, params, batches=batches, scales=scales)

--- a/Modules/Report/__init__.py
+++ b/Modules/Report/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import copy
 import os
 from collections import OrderedDict
 from six.moves import cStringIO as StringIO

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -1624,6 +1624,6 @@ def anomalous_probability_plot(intensities, expected_delta=None):
         y = y.select(sel)
 
     fit = flex.linear_regression(x, y)
-    assert fit.is_well_defined()
-
-    return fit.slope(), fit.y_intercept(), x.size()
+    if fit.is_well_defined():
+        return fit.slope(), fit.y_intercept(), x.size()
+    return None, None, None

--- a/Test/regression/test_multiplex.py
+++ b/Test/regression/test_multiplex.py
@@ -1,37 +1,78 @@
 from __future__ import absolute_import, division, print_function
 
-import procrunner
 import pytest
 
-expected_data_files = ["scaled.mtz", "scaled_unmerged.mtz", "xia2.multiplex.html"]
+from dxtbx.serialize import load
+from xia2.command_line.multiplex import run
+
+expected_data_files = [
+    "multiplex.expt",
+    "multiplex.refl",
+    "scaled.mtz",
+    "scaled_unmerged.mtz",
+    "xia2.multiplex.html",
+]
 
 
-def test_proteinase_k(regression_test, ccp4, dials_data, run_in_tmpdir):
+def test_proteinase_k(regression_test, ccp4, dials_data, tmpdir):
     data_dir = dials_data("multi_crystal_proteinase_k")
     expts = sorted(f.strpath for f in data_dir.listdir("experiments*.json"))
     refls = sorted(f.strpath for f in data_dir.listdir("reflections*.pickle"))
-    command_line = ["xia2.multiplex"] + expts + refls
-    print(" ".join(command_line))
-    result = procrunner.run(command_line)
-    assert not result["exitcode"]
+    with tmpdir.as_cwd():
+        run(expts + refls)
     for f in expected_data_files:
-        assert run_in_tmpdir.join(f).check(file=1), "expected file %s missing" % f
+        assert tmpdir.join(f).check(file=1), "expected file %s missing" % f
+    multiplex_expts = load.experiment_list(
+        tmpdir.join("multiplex.expt").strpath, check_format=False
+    )
+    for expt in multiplex_expts:
+        assert expt.crystal.get_space_group().type().lookup_symbol() == "P 41 21 2"
 
 
-@pytest.mark.parametrize("space_group", [None, "P422"])
+@pytest.mark.parametrize(
+    "laue_group,space_group", [("P422", None), (None, "P422"), (None, "P43212")]
+)
 def test_proteinase_k_dose(
-    space_group, regression_test, ccp4, dials_data, run_in_tmpdir
+    laue_group, space_group, regression_test, ccp4, dials_data, tmpdir
 ):
     data_dir = dials_data("multi_crystal_proteinase_k")
     expts = sorted(f.strpath for f in data_dir.listdir("experiments*.json"))
     refls = sorted(f.strpath for f in data_dir.listdir("reflections*.pickle"))
-    command_line = (
-        ["xia2.multiplex", "dose=1,20", "symmetry.space_group=%s" % space_group]
+    command_line_args = (
+        [
+            "dose=1,20",
+            "symmetry.laue_group=%s" % laue_group,
+            "symmetry.space_group=%s" % space_group,
+        ]
         + expts
         + refls
     )
-    print(" ".join(command_line))
-    result = procrunner.run(command_line)
-    assert not result["exitcode"]
+    with tmpdir.as_cwd():
+        run(command_line_args)
     for f in expected_data_files:
-        assert run_in_tmpdir.join(f).check(file=1), "expected file %s missing" % f
+        assert tmpdir.join(f).check(file=1), "expected file %s missing" % f
+    multiplex_expts = load.experiment_list(
+        tmpdir.join("multiplex.expt").strpath, check_format=False
+    )
+    for expt in multiplex_expts:
+        if space_group is None:
+            assert expt.crystal.get_space_group().type().lookup_symbol() == "P 41 21 2"
+        else:
+            assert (
+                expt.crystal.get_space_group().type().lookup_symbol().replace(" ", "")
+                == space_group
+            )
+
+
+def test_proteinase_k_laue_group_space_group_raises_error(
+    regression_test, ccp4, dials_data, tmpdir
+):
+    data_dir = dials_data("multi_crystal_proteinase_k")
+    expts = sorted(f.strpath for f in data_dir.listdir("experiments*.json"))
+    refls = sorted(f.strpath for f in data_dir.listdir("reflections*.pickle"))
+    command_line_args = (
+        ["symmetry.laue_group=P422", "symmetry.space_group=P41212"] + expts + refls
+    )
+    with tmpdir.as_cwd():
+        with pytest.raises(SystemExit):
+            run(command_line_args)

--- a/Wrappers/XDS/XScaleR.py
+++ b/Wrappers/XDS/XScaleR.py
@@ -9,7 +9,7 @@ import shutil
 from xia2.Driver.DriverFactory import DriverFactory
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Streams import Debug
-from xia2.Wrappers.XDS.XDS import xds_check_error
+from xia2.Wrappers.XDS.XDS import xds_check_error, get_xds_version
 from xia2.Wrappers.XDS.XScaleHelpers import get_correlation_coefficients_and_group
 
 
@@ -38,6 +38,8 @@ def XScaleR(
                 self.set_executable("xscale_par")
 
             self._version = "new"
+
+            self._built = int(get_xds_version().split("=")[-1])
 
             # overall information
             self._resolution_shells = ""
@@ -152,9 +154,12 @@ def XScaleR(
             xscale_inp.write(
                 "%6.2f %6.2f %6.2f %6.2f %6.2f %6.2f\n" % tuple(self._cell)
             )
-            xscale_inp.write(
-                "MINIMUM_I/SIGMA=%.1f\n" % PhilIndex.params.xds.xscale.min_isigma
-            )
+            if self._built >= 20191015:
+                xscale_inp.write("SNRC=%.1f\n" % PhilIndex.params.xds.xscale.min_isigma)
+            else:
+                xscale_inp.write(
+                    "MINIMUM_I/SIGMA=%.1f\n" % PhilIndex.params.xds.xscale.min_isigma
+                )
 
             if self._reindex_matrix:
                 xscale_inp.write(

--- a/command_line/multiplex.py
+++ b/command_line/multiplex.py
@@ -119,10 +119,10 @@ def run(args):
         params.identifiers = identifiers
 
     try:
-        scaled = ScaleAndMerge.MultiCrystalScale(experiments, reflections_all, params)
+        ScaleAndMerge.MultiCrystalScale(experiments, reflections_all, params)
     except ValueError as e:
         sys.exit(str(e))
 
 
 if __name__ == "__main__":
-    run()
+    run(sys.argv[1:])

--- a/command_line/multiplex.py
+++ b/command_line/multiplex.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function
 import logging
 import random
 from collections import OrderedDict
+import sys
 
 import iotbx.phil
-from dials.util import Sorry
 
 import xia2.Handlers.Streams
 from dials.array_family import flex
@@ -40,7 +40,7 @@ output {
 )
 
 
-def run():
+def run(args):
     usage = (
         "xia2.multiplex [options] [param.phil] "
         "models1.expt models2.expt observations1.refl "
@@ -58,7 +58,7 @@ def run():
     )
 
     # Parse the command line
-    params, options = parser.parse_args(show_diff_phil=False)
+    params, options = parser.parse_args(args=args, show_diff_phil=False)
 
     # Configure the logging
     xia2.Handlers.Streams.streams_off()
@@ -86,7 +86,7 @@ def run():
     try:
         assert len(params.input.reflections) == len(params.input.experiments)
     except AssertionError:
-        raise Sorry(
+        raise sys.exit(
             "The number of input reflections files does not match the "
             "number of input experiments"
         )
@@ -117,7 +117,11 @@ def run():
         for identifier in params.identifiers:
             identifiers.extend(identifier.split(","))
         params.identifiers = identifiers
-    scaled = ScaleAndMerge.MultiCrystalScale(experiments, reflections_all, params)
+
+    try:
+        scaled = ScaleAndMerge.MultiCrystalScale(experiments, reflections_all, params)
+    except ValueError as e:
+        sys.exit(str(e))
 
 
 if __name__ == "__main__":

--- a/newsfragments/355.feature
+++ b/newsfragments/355.feature
@@ -1,0 +1,7 @@
+Perform systematic absence analysis in multiplex
+
+- Run dials.symmetry in systematic-absences-only mode after scaling to determine
+  full space group in xia2.multiplex
+- Set laue_group= to skip Laue group determination by dials.cosym
+- Set space_group= to skip both Laue group determination by dials.cosym and
+  systematic absences analysis by dials.symmetry

--- a/newsfragments/357.bugfix
+++ b/newsfragments/357.bugfix
@@ -1,0 +1,1 @@
+Don't raise error if anomalous probability plot fails


### PR DESCRIPTION
* allow running dials pipeline with ccp4a scaler (#363)
* fix `fit.is_well_defined()` error (#357)
* fix pychef plots for xia2.multiplex
* support newer versions of XDS (#354)
* ensure correct detector thickness is used throughout the XDS pipeline (#372)
* xia2.multiplex now performs systematic absence analysis (#355)