### PR TITLE
DIALS 2.0.3

### DIFF
--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -68,12 +68,15 @@ class DialsIntegrater(Integrater):
     # admin functions
 
     def get_integrated_experiments(self):
+        self.integrate()
         return self._intgr_experiments_filename
 
     def get_integrated_filename(self):
+        self.integrate()
         return self._intgr_integrated_filename
 
     def get_integrated_reflections(self):
+        self.integrate()
         return self._intgr_integrated_reflections
 
     def set_integrated_experiments(self, filename):

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -829,8 +829,11 @@ class Scale(object):
             scaler.set_best_unit_cell(self.best_unit_cell)
 
         scaler.set_full_matrix(False)
-        if self._params.scaling.dials.model is not None:
-            scaler.set_model(self._params.scaling.dials.model)
+
+        # Set default scaling model
+        if self._params.scaling.dials.model in (None, "auto", Auto):
+            self._params.scaling.dials.model = "physical"
+        scaler.set_model(self._params.scaling.dials.model)
         scaler.set_outlier_rejection(self._params.scaling.dials.outlier_rejection)
 
         scaler.scale()

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -5,6 +5,8 @@ import os
 import math
 
 from orderedset import OrderedSet
+import libtbx
+
 from xia2.Handlers.Files import FileHandler
 from xia2.lib.bits import auto_logfiler
 from xia2.Handlers.Phil import PhilIndex
@@ -71,6 +73,10 @@ class DialsScaler(Scaler):
 
         resolution = PhilIndex.params.xia2.settings.resolution
         self._scaler.set_resolution(d_min=resolution.d_min, d_max=resolution.d_max)
+
+        # Set default scaling model
+        if PhilIndex.params.dials.scale.model in (None, "auto", libtbx.Auto):
+            PhilIndex.params.dials.scale.model = "physical"
 
         self._scaler.set_model(PhilIndex.params.dials.scale.model)
         self._scaler.set_intensities(PhilIndex.params.dials.scale.intensity_choice)

--- a/Wrappers/Dials/Scale.py
+++ b/Wrappers/Dials/Scale.py
@@ -7,7 +7,6 @@ import os
 from xia2.Driver.DriverFactory import DriverFactory
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Streams import Chatter, Debug
-from libtbx import Auto
 
 
 def DialsScale(DriverType=None, decay_correction=None):
@@ -239,18 +238,16 @@ def DialsScale(DriverType=None, decay_correction=None):
             elif self._intensities == "profile":
                 self.add_command_line("intensity_choice=profile")
 
-            if self._model is not None:
-                self.add_command_line("model=%s" % self._model)
+            assert self._model is not None
+            self.add_command_line("model=%s" % self._model)
             if self._absorption_correction:
-                if self._model in (None, Auto, "physical"):
-                    self.add_command_line("physical.absorption_correction=True")
-                elif self._model == "array":
-                    self.add_command_line("array.absorption_correction=True")
+                self.add_command_line("%s.absorption_correction=True" % self._model)
             if self._bfactor:
-                if self._model in (None, Auto, "physical"):
-                    self.add_command_line("physical.decay_correction=True")
-                elif self._model == "array":
-                    self.add_command_line("array.decay_correction=True")
+                self.add_command_line("%s.decay_correction=True" % self._model)
+                if self._brotation is not None:
+                    self.add_command_line(
+                        "%s.decay_interval=%g" % (self._model, self._brotation)
+                    )
 
             self.add_command_line("full_matrix=%s" % self._full_matrix)
             if self._spacing:
@@ -266,9 +263,6 @@ def DialsScale(DriverType=None, decay_correction=None):
 
             if self._partiality_cutoff is not None:
                 self.add_command_line("partiality_cutoff=%s" % self._partiality_cutoff)
-
-            if self._bfactor and self._brotation is not None:
-                self.add_command_line("decay_interval=%g" % self._brotation)
 
             # next any 'generic' parameters
 

--- a/Wrappers/Dials/Symmetry.py
+++ b/Wrappers/Dials/Symmetry.py
@@ -226,7 +226,10 @@ def DialsSymmetry(DriverType=None):
             if PhilIndex.params.xia2.settings.symmetry.chirality in (None, "chiral"):
                 patterson_group = patterson_group.build_derived_acentric_group()
             cb_op_min_best = sgtbx.change_of_basis_op(str(best_solution["cb_op"]))
-            assert len(d["cb_op_inp_min"]) == 1
+            # This should only be called with multiple sweeps if they're already
+            # consistently indexed, so assert that they all have the same
+            # cb_op_inp_min
+            assert len(set(d["cb_op_inp_min"])) == 1
             cb_op_inp_min = sgtbx.change_of_basis_op(str(d["cb_op_inp_min"][0]))
 
             min_cell = uctbx.unit_cell(d["min_cell_symmetry"]["unit_cell"])

--- a/Wrappers/XDS/XDS.py
+++ b/Wrappers/XDS/XDS.py
@@ -356,10 +356,12 @@ def imageset_to_xds(
             )
             result.append("")
 
-    for f0, s0, f1, s1 in converter.get_detector()[0].get_mask():
-        result.append(
-            "UNTRUSTED_RECTANGLE= %d %d %d %d" % (f0 - 1, f1 + 1, s0 - 1, s1 + 1)
-        )
+    for panel, (x0, _, y0, _) in zip(converter.get_detector(), converter.panel_limits):
+        for f0, s0, f1, s1 in panel.get_mask():
+            result.append(
+                "UNTRUSTED_RECTANGLE= %d %d %d %d"
+                % (f0 + x0 - 1, f1 + x0, s0 + y0 - 1, s1 + y0)
+            )
 
     if params.xds.untrusted_ellipse:
         for untrusted_ellipse in params.xds.untrusted_ellipse:

--- a/newsfragments/379.bugfix
+++ b/newsfragments/379.bugfix
@@ -1,0 +1,2 @@
+Ensure that integration results are copied to DataFiles. In some circumstances,
+when re-indexing/integrating the data, they were inadvertently missed (#379)

--- a/newsfragments/390.bugfix
+++ b/newsfragments/390.bugfix
@@ -1,0 +1,1 @@
+Fix for running dials.symmetry in multi_sweep_indexing mode


### PR DESCRIPTION
* Ensure that integration results are copied to DataFiles. (#379)
* Correctly set untrusted regions on multi-panel detectors with the XDS pipeline (#387)
* Fix crash when running `dials.symmetry` in multisweep mode (#390)

