### PR TITLE
XDS untrusted_rectangles: iterate over all panels

### DIFF
--- a/Wrappers/XDS/XDS.py
+++ b/Wrappers/XDS/XDS.py
@@ -296,20 +296,20 @@ def imageset_to_xds(
             )
             result.append("")
 
-    for f0, s0, f1, s1 in converter.get_detector()[0].get_mask():
-        result.append(
-            "UNTRUSTED_RECTANGLE= %d %d %d %d" % (f0 - 1, f1 + 1, s0 - 1, s1 + 1)
-        )
+    for panel, (x0, _, y0, _) in zip(converter.get_detector(), converter.panel_limits):
+        for f0, s0, f1, s1 in panel.get_mask():
+            result.append(
+                "UNTRUSTED_RECTANGLE= %d %d %d %d"
+                % (f0 + x0 - 1, f1 + x0, s0 + y0 - 1, s1 + y0)
+            )
 
     if params.xds.untrusted_ellipse:
         for untrusted_ellipse in params.xds.untrusted_ellipse:
             result.append("UNTRUSTED_ELLIPSE= %d %d %d %d" % tuple(untrusted_ellipse))
         Debug.write(result[-1])
 
-    untrusted_rectangles = converter.untrusted_rectangles
-    untrusted_rectangles.extend(params.xds.untrusted_rectangle)
-    if untrusted_rectangles:
-        for untrusted_rectangle in untrusted_rectangles:
+    if params.xds.untrusted_rectangle:
+        for untrusted_rectangle in params.xds.untrusted_rectangle:
             result.append(
                 "UNTRUSTED_RECTANGLE= %d %d %d %d" % tuple(untrusted_rectangle)
             )

--- a/Wrappers/XDS/XDS.py
+++ b/Wrappers/XDS/XDS.py
@@ -306,8 +306,17 @@ def imageset_to_xds(
             result.append("UNTRUSTED_ELLIPSE= %d %d %d %d" % tuple(untrusted_ellipse))
         Debug.write(result[-1])
 
-    if params.xds.untrusted_rectangle:
-        for untrusted_rectangle in params.xds.untrusted_rectangle:
+    untrusted_rectangles = params.xds.untrusted_rectangle
+    format_instance = imageset.get_format_class().get_instance(imageset.paths()[0])
+    if format_instance.get_untrusted_regions():
+        untrusted_rectangles = untrusted_rectangles + [
+            region.rectangle
+            for region in format_instance.get_untrusted_regions()
+            if region.rectangle is not None
+        ]
+
+    if untrusted_rectangles:
+        for untrusted_rectangle in untrusted_rectangles:
             result.append(
                 "UNTRUSTED_RECTANGLE= %d %d %d %d" % tuple(untrusted_rectangle)
             )

--- a/Wrappers/XDS/XDS.py
+++ b/Wrappers/XDS/XDS.py
@@ -306,15 +306,8 @@ def imageset_to_xds(
             result.append("UNTRUSTED_ELLIPSE= %d %d %d %d" % tuple(untrusted_ellipse))
         Debug.write(result[-1])
 
-    untrusted_rectangles = params.xds.untrusted_rectangle
-    format_instance = imageset.get_format_class().get_instance(imageset.paths()[0])
-    if format_instance.get_untrusted_regions():
-        untrusted_rectangles = untrusted_rectangles + [
-            region.rectangle
-            for region in format_instance.get_untrusted_regions()
-            if region.rectangle is not None
-        ]
-
+    untrusted_rectangles = converter.untrusted_rectangles
+    untrusted_rectangles.extend(params.xds.untrusted_rectangle)
     if untrusted_rectangles:
         for untrusted_rectangle in untrusted_rectangles:
             result.append(


### PR DESCRIPTION
Iterate over all panels when adding untrusted rectangles to XDS.INP.
See also https://github.com/cctbx/dxtbx/pull/121.