### PR TITLE
Raise warning in case of tolerance error

### DIFF
--- a/Test/regression/__init__.py
+++ b/Test/regression/__init__.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import, division, print_function
 import os
 import platform
 import re
-
 import six
+import warnings
+
 import xia2.Test.regression
 
 default_data_files = [
@@ -13,6 +14,10 @@ default_data_files = [
     "AUTOMATIC_DEFAULT_scaled_unmerged.mtz",
     "AUTOMATIC_DEFAULT_scaled_unmerged.sca",
 ]
+
+
+class Xia2RegressionToleranceWarning(UserWarning):
+    pass
 
 
 def check_result(
@@ -215,7 +220,9 @@ def check_result(
         return False, "xia2.html not present after execution"
 
     if not output_identical:
-        return False, "xia2 output failing tolerance checks"
+        warnings.warn(
+            "xia2 output failing tolerance checks", Xia2RegressionToleranceWarning
+        )
     return True, "All OK"
 
 


### PR DESCRIPTION
Instead of failing in cases of regression test tolerance failures, this will now raise a custom warning. Pytest can be run with the -W option to treat this warning as an error:
`$ pytest --regression-full -W error::xia2.Test.regression.Xia2RegressionToleranceWarning`

Running pytest with default behaviour:
```
$ pytest Test/regression/test_X4_wide.py --regression-full -n auto
...
============================================================================================= warnings summary =============================================================================================
Test/regression/__init__.py:224
Test/regression/__init__.py:224
Test/regression/__init__.py:224
Test/regression/__init__.py:224
Test/regression/__init__.py:224
Test/regression/__init__.py:224
Test/regression/__init__.py:224
Test/regression/__init__.py:224
  /Users/rjgildea/software/cctbx/modules/xia2/Test/regression/__init__.py:224: Xia2RegressionToleranceWarning: xia2 output failing tolerance checks
    "xia2 output failing tolerance checks", Xia2RegressionToleranceWarning

-- Docs: https://docs.pytest.org/en/latest/warnings.html

Results (1121.06s):
      12 passed
```

Running pytest treating warning as error:
```
$ pytest Test/regression/test_X4_wide.py --regression-full -W error::xia2.Test.regression.Xia2RegressionToleranceWarning -n auto
...
Results (1334.83s):
       2 passed
      10 failed
         - Test/regression/test_X4_wide.py:160 test_xds
         - Test/regression/test_X4_wide.py:176 test_xds_split
         - Test/regression/test_X4_wide.py:116 test_dials_aimless_split
         - Test/regression/test_X4_wide.py:133 test_dials_split[False]
         - Test/regression/test_X4_wide.py:71 test_dials_aimless_with_dials_pipeline
         - Test/regression/test_X4_wide.py:54 test_dials_aimless
         - Test/regression/test_X4_wide.py:90 test_dials
         - Test/regression/test_X4_wide.py:133 test_dials_split[True]
         - Test/regression/test_X4_wide.py:193 test_xds_ccp4a
         - Test/regression/test_X4_wide.py:209 test_xds_ccp4a_split
```