### PR TITLE
Prescale data when multi_sweep_indexing

### DIFF
--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -119,6 +119,28 @@ class DialsScaler(Scaler):
 
         return self._scaler
 
+    def _do_prescale_kb(self, experiments, reflections):
+        # Pre-scale the data with KB scaling to ensure all experiments are on
+        # the same scale prior to running dials.symmetry
+        self._scaler = DialsScale()
+        self._scaler = self._updated_dials_scaler()
+        self._scaler.set_model("KB")
+        self._scaler.set_full_matrix(False)
+        self._scaler.set_error_model(None)
+        self._scaler.set_intensities("profile")
+
+        for expts, refl in zip(experiments, reflections):
+            self._scaler.add_experiments_json(expts)
+            self._scaler.add_reflections_file(refl)
+
+        self._scaler.set_working_directory(self.get_working_directory())
+        auto_logfiler(self._scaler)
+        self._scaler.scale()
+        prescaled_experiments = self._scaler.get_scaled_experiments()
+        prescaled_reflections = self._scaler.get_scaled_reflections()
+        self._scaler = None
+        return prescaled_experiments, prescaled_reflections
+
     def _do_multisweep_symmetry_analysis(self):
         refiners = []
         experiments = []
@@ -131,6 +153,10 @@ class DialsScaler(Scaler):
             reflections.append(integrater.get_integrated_reflections())
             refiners.append(integrater.get_integrater_refiner())
 
+        prescaled_experiments, prescaled_reflections = self._do_prescale_kb(
+            experiments, reflections
+        )
+
         Debug.write("Running multisweep dials.symmetry for %d sweeps" % len(refiners))
         (
             pointgroup,
@@ -141,7 +167,7 @@ class DialsScaler(Scaler):
             reind_exp,
             reindex_initial,
         ) = self._dials_symmetry_indexer_jiffy(
-            experiments, reflections, refiners, multisweep=True
+            [prescaled_experiments], [prescaled_reflections], refiners, multisweep=True
         )
 
         FileHandler.record_temporary_file(reind_refl)
@@ -531,6 +557,9 @@ pipeline=dials (supported for pipeline=dials-aimless).
             for si in sweep_infos:
                 self._scaler.add_experiments_json(si.get_experiments())
                 self._scaler.add_reflections_file(si.get_reflections())
+            # ensure we start with a clean slate in case we pre-scaled the data
+            # before running dials.symmetry
+            self._scaler.set_overwrite_existing_models(True)
 
         self._scalr_scaled_reflection_files = {}
         self._scalr_scaled_reflection_files["mtz_unmerged"] = {}

--- a/Wrappers/Dials/Scale.py
+++ b/Wrappers/Dials/Scale.py
@@ -37,6 +37,7 @@ def DialsScale(DriverType=None, decay_correction=None):
             self._d_min = None
             self._d_max = None
             self._crystal_name = None
+            self._overwrite_existing_models = None
 
             # input and output files
             self._unmerged_reflections = None
@@ -203,6 +204,9 @@ def DialsScale(DriverType=None, decay_correction=None):
         def set_best_unit_cell(self, unit_cell):
             self._best_unit_cell = unit_cell
 
+        def set_overwrite_existing_models(self, overwrite):
+            self._overwrite_existing_models = overwrite
+
         def scale(self):
             """Actually perform the scaling."""
 
@@ -228,11 +232,14 @@ def DialsScale(DriverType=None, decay_correction=None):
 
             assert self._model is not None
             self.add_command_line("model=%s" % self._model)
-            if self._absorption_correction:
-                self.add_command_line("%s.absorption_correction=True" % self._model)
+
             if self._bfactor:
                 self.add_command_line("%s.decay_correction=True" % self._model)
-                if self._brotation is not None:
+
+            if self._model != "KB":
+                if self._absorption_correction:
+                    self.add_command_line("%s.absorption_correction=True" % self._model)
+                if self._bfactor and self._brotation is not None:
                     self.add_command_line(
                         "%s.decay_interval=%g" % (self._model, self._brotation)
                     )
@@ -280,6 +287,8 @@ def DialsScale(DriverType=None, decay_correction=None):
                 self.add_command_line(
                     "best_unit_cell=%s,%s,%s,%s,%s,%s" % self._best_unit_cell
                 )
+            if self._overwrite_existing_models is not None:
+                self.add_command_line("overwrite_existing_models=True")
 
             if not self._scaled_experiments:
                 self._scaled_experiments = os.path.join(

--- a/newsfragments/395.feature
+++ b/newsfragments/395.feature
@@ -1,0 +1,6 @@
+Prescale data before dials.symmetry when in multi_sweep_indexing mode
+
+This mirrors the behaviour of the CCP4ScalerA by prescaling the data
+with KB scaling to ensure that all experiments are on the same scale
+before running dials.symmetry. This should lead to more reliable
+results from the symmetry analysis in multi_sweep_indexing mode.


### PR DESCRIPTION
This mirrors the behaviour of the CCP4ScalerA by prescaling the data with KB scaling to ensure that all experiments are on the same scale before running dials.symmetry. This should lead to more reliable results from the symmetry analysis when running in multi_sweep_indexing mode.