### PR TITLE
Improve handling of diamond anvil cell data

### DIFF
--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -409,8 +409,8 @@ dials
       per_degree = None
         .type = int(value_min=0)
         .optional = True
-        .help = "The minimum number of reflections per degree of sweep needed to do "
-                "the profile modelling."
+        .help = "Minimum number of reflections per degree of sweep required to perform "
+                "profile modelling."
     }
   }
 

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding: utf-8
 # Phil.py
 #   Copyright (C) 2012 Diamond Light Source, Graeme Winter
 #
@@ -15,7 +16,7 @@ from iotbx.phil import parse
 from libtbx.phil import interface
 
 master_phil = parse(
-    """
+    u"""
 general
   .short_caption = "General settings"
 {
@@ -396,6 +397,13 @@ dials
       .type = float(value_min=0.0)
       .short_caption = "Low resolution cutoff for integration"
       .expert_level = 1
+  }
+  high_pressure = False
+    .type = bool
+    .expert_level = 1
+    .short_caption = "Handle diamond anvil pressure cell data"
+  {
+    include scope dials.command_line.rescale_diamond_anvil_cell.phil_scope
   }
   scale
     .expert_level = 1

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -398,11 +398,14 @@ dials
       .short_caption = "Low resolution cutoff for integration"
       .expert_level = 1
   }
-  high_pressure = False
-    .type = bool
+  high_pressure
     .expert_level = 1
     .short_caption = "Handle diamond anvil pressure cell data"
   {
+    correct = False
+      .type = bool
+      .short_caption = "Whether to correct for attenuation by a diamond anvil cell"
+
     include scope dials.command_line.rescale_diamond_anvil_cell.phil_scope
   }
   scale

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -401,7 +401,7 @@ dials
       .short_caption = "Override default profile parameters of dials.integrate"
     {
       overall = None
-        .type = int(value_min=0)
+        .type = int(value_min=1)
         .optional = True
         .help = "The minimum number of reflections needed to do the profile "
                 "modelling."

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -422,7 +422,7 @@ dials
       .type = bool
       .short_caption = "Whether to correct for attenuation by a diamond anvil cell"
 
-    include scope dials.command_line.rescale_diamond_anvil_cell.phil_scope
+    include scope dials.command_line.anvil_correction.phil_scope
   }
 
   scale

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -403,7 +403,7 @@ dials
       overall = None
         .type = int(value_min=1)
         .optional = True
-        .help = "The minimum number of reflections needed to do the profile "
+        .help = "Minimum number of reflections required to perform profile "
                 "modelling."
 
       per_degree = None

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -420,7 +420,7 @@ dials
   {
     correction = False
       .type = bool
-      .short_caption = "Whether to correct for attenuation by a diamond anvil cell"
+      .help = "Correct for attenuation by a diamond anvil cell"
 
     include scope dials.command_line.anvil_correction.phil_scope
   }

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -397,17 +397,34 @@ dials
       .type = float(value_min=0.0)
       .short_caption = "Low resolution cutoff for integration"
       .expert_level = 1
+    min_spots
+      .short_caption = "Override default profile parameters of dials.integrate"
+    {
+      overall = None
+        .type = int(value_min=0)
+        .optional = True
+        .help = "The minimum number of reflections needed to do the profile "
+                "modelling."
+
+      per_degree = None
+        .type = int(value_min=0)
+        .optional = True
+        .help = "The minimum number of reflections per degree of sweep needed to do "
+                "the profile modelling."
+    }
   }
+
   high_pressure
     .expert_level = 1
     .short_caption = "Handle diamond anvil pressure cell data"
   {
-    correct = False
+    correction = False
       .type = bool
       .short_caption = "Whether to correct for attenuation by a diamond anvil cell"
 
     include scope dials.command_line.rescale_diamond_anvil_cell.phil_scope
   }
+
   scale
     .expert_level = 1
     .short_caption = "Scaling"

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -402,8 +402,8 @@ class DialsIntegrater(Integrater):
             rescale_dac.clear_command_line()
 
             # Take the filenames of the last integration step as input.
-            rescale_dac.experiments_filename = self._intgr_experiments_filename
-            rescale_dac.reflections_filename = self._intgr_integrated_reflections
+            rescale_dac.experiments_filenames.append(self._intgr_experiments_filename)
+            rescale_dac.reflections_filename.append(self._intgr_integrated_reflections)
 
             # The output reflections have a filename appended with '_corrected'.
             output_reflections = rescale_dac.reflections_filename.replace(

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -17,7 +17,7 @@ from xia2.Schema.Interfaces.Integrater import Integrater
 
 from xia2.Wrappers.Dials.ExportMtz import ExportMtz as _ExportMtz
 from xia2.Wrappers.Dials.Report import Report as _Report
-from xia2.Wrappers.Dials.rescale_diamond_anvil_cell import rescale_dac as _rescale_dac
+from xia2.Wrappers.Dials.anvil_correction import rescale_dac as _rescale_dac
 
 
 class DialsIntegrater(Integrater):
@@ -377,7 +377,7 @@ class DialsIntegrater(Integrater):
         """
         Finish off the integration.
 
-        If in high-pressure mode run dials.rescale_diamond_anvil_cell.
+        If in high-pressure mode run dials.anvil_correction.
 
         Run dials.export.
         """
@@ -388,7 +388,7 @@ class DialsIntegrater(Integrater):
         # that we do; these can be very large) - was exporter.get_xpid() ->
         # now dials
 
-        # If running in high-pressure mode, run dials.rescale_diamond_anvil_cell to
+        # If running in high-pressure mode, run dials.anvil_correction to
         # correct for the attenuation of the incident and diffracted beams by the
         # diamond anvils.
         if PhilIndex.params.dials.high_pressure.correction:
@@ -416,7 +416,7 @@ class DialsIntegrater(Integrater):
             rescale_dac.thickness = params.anvil.thickness
             rescale_dac.normal = params.anvil.normal
 
-            # Run dials.rescale_diamond_anvil_cell with the parameters as set above.
+            # Run dials.anvil_correction with the parameters as set above.
             rescale_dac.set_working_directory(self.get_working_directory())
             auto_logfiler(rescale_dac)
             rescale_dac()

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -45,6 +45,9 @@ class DialsIntegrater(Integrater):
         self._intgr_integrated_reflections = None
         self._intgr_experiments_filename = None
 
+        # Check whether to do diamond anvil cell attenuation correction.
+        self.high_pressure = PhilIndex.params.dials.high_pressure.correction
+
     # overload these methods as we don't want the resolution range
     # feeding back... aha - but we may want to assign them
     # from outside!
@@ -370,7 +373,7 @@ class DialsIntegrater(Integrater):
         # If running in high-pressure mode, run dials.anvil_correction to
         # correct for the attenuation of the incident and diffracted beams by the
         # diamond anvils.
-        if PhilIndex.params.dials.high_pressure.correction:
+        if self.high_pressure:
             logger.info(
                 "Rescaling integrated reflections for attenuation in the "
                 "diamond anvil cell."

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -403,10 +403,10 @@ class DialsIntegrater(Integrater):
 
             # Take the filenames of the last integration step as input.
             rescale_dac.experiments_filenames.append(self._intgr_experiments_filename)
-            rescale_dac.reflections_filename.append(self._intgr_integrated_reflections)
+            rescale_dac.reflections_filenames.append(self._intgr_integrated_reflections)
 
             # The output reflections have a filename appended with '_corrected'.
-            output_reflections = rescale_dac.reflections_filename.replace(
+            output_reflections = self._intgr_integrated_reflections.replace(
                 ".refl", "_corrected.refl"
             )
             rescale_dac.output_reflections_filename = output_reflections

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -374,7 +374,13 @@ class DialsIntegrater(Integrater):
         return self._intgr_integrated_reflections
 
     def _integrate_finish(self):
-        """Finish off the integration by running dials.export."""
+        """
+        Finish off the integration.
+
+        If in high-pressure mode run dials.rescale_diamond_anvil_cell.
+
+        Run dials.export.
+        """
 
         # FIXME - do we want to export every time we call this method
         # (the file will not have changed) and also (more important) do
@@ -411,6 +417,7 @@ class DialsIntegrater(Integrater):
             rescale_dac.normal = params.anvil.normal
 
             # Run dials.rescale_diamond_anvil_cell with the parameters as set above.
+            rescale_dac.set_working_directory(self.get_working_directory())
             auto_logfiler(rescale_dac)
             rescale_dac()
 

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -79,7 +79,7 @@ class DialsIntegrater(Integrater):
 
     # factory functions
 
-    def Integrate(self, indexed_filename=None):
+    def Integrate(self):
         params = PhilIndex.params.dials.integrate
         integrate = xia2.Wrappers.Dials.Integrate.Integrate()
         integrate.set_phil_file(params.phil_file)
@@ -93,7 +93,13 @@ class DialsIntegrater(Integrater):
             profile_fitting = PhilIndex.params.xia2.settings.integration.profile_fitting
             integrate.set_profile_fitting(profile_fitting)
 
+        # Options for profile modelling.
         integrate.set_scan_varying_profile(params.scan_varying_profile)
+
+        high_pressure = PhilIndex.params.dials.high_pressure.correction
+        integrate.set_profile_params(
+            params.min_spots.per_degree, params.min_spots.overall, high_pressure
+        )
 
         integrate.set_background_outlier_algorithm(params.background_outlier_algorithm)
         integrate.set_background_algorithm(params.background_algorithm)
@@ -256,14 +262,6 @@ class DialsIntegrater(Integrater):
         else:
             integrate.set_d_min(self._intgr_reso_high)
 
-        # Options for profile modelling.
-        high_pressure = PhilIndex.params.dials.high_pressure.correction
-        min_spots_per_degree = PhilIndex.params.dials.integrate.min_spots.per_degree
-        min_spots_overall = PhilIndex.params.dials.integrate.min_spots.overall
-        integrate.set_profile_params(
-            min_spots_per_degree, min_spots_overall, high_pressure
-        )
-
         pname, xname, dname = self.get_integrater_project_info()
         sweep = self.get_integrater_sweep_name()
         FileHandler.record_log_file(
@@ -298,11 +296,6 @@ class DialsIntegrater(Integrater):
                         start - self.get_matching_images()[0],
                         stop - self.get_matching_images()[0],
                     )
-
-                # Options for profile modelling.
-                integrate.set_profile_params(
-                    min_spots_per_degree, min_spots_overall, high_pressure
-                )
 
                 integrate.set_reflections_per_degree(1000)
                 integrate.run()

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -377,7 +377,7 @@ class DialsIntegrater(Integrater):
         # If running in high-pressure mode, run dials.rescale_diamond_anvil_cell to
         # correct for the attenuation of the incident and diffracted beams by the
         # diamond anvils.
-        if PhilIndex.params.dials.high_pressure:
+        if PhilIndex.params.dials.high_pressure.correct:
             params = PhilIndex.params.dials.high_pressure
             rescale_dac = _rescale_dac()
 

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -381,15 +381,14 @@ class DialsIntegrater(Integrater):
 
             params = PhilIndex.params.dials.high_pressure
             rescale_dac = _rescale_dac()
-            rescale_dac.clear_command_line()
 
             # Take the filenames of the last integration step as input.
             rescale_dac.experiments_filenames.append(self._intgr_experiments_filename)
             rescale_dac.reflections_filenames.append(self._intgr_integrated_reflections)
 
             # The output reflections have a filename appended with '_corrected'.
-            output_reflections = self._intgr_integrated_reflections.replace(
-                ".refl", "_corrected.refl"
+            output_reflections = "_corrected".join(
+                os.path.splitext(self._intgr_integrated_reflections)
             )
             rescale_dac.output_reflections_filename = output_reflections
 
@@ -401,7 +400,7 @@ class DialsIntegrater(Integrater):
             # Run dials.anvil_correction with the parameters as set above.
             rescale_dac.set_working_directory(self.get_working_directory())
             auto_logfiler(rescale_dac)
-            rescale_dac()
+            rescale_dac.run()
             self._intgr_integrated_reflections = output_reflections
 
         if self._output_format == "hkl":

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -371,7 +371,7 @@ class DialsIntegrater(Integrater):
         # correct for the attenuation of the incident and diffracted beams by the
         # diamond anvils.
         if PhilIndex.params.dials.high_pressure.correction:
-            Chatter.write(
+            logger.info(
                 "Rescaling integrated reflections for attenuation in the "
                 "diamond anvil cell."
             )

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -382,8 +382,8 @@ class DialsIntegrater(Integrater):
             rescale_dac = _rescale_dac()
 
             # Take the filenames of the last integration step as input.
-            rescale_dac.experiments_filename = self.get_integrated_experiments()
-            rescale_dac.reflections_filename = self.get_integrated_reflections()
+            rescale_dac.experiments_filename = self._intgr_experiments_filename
+            rescale_dac.reflections_filename = self._intgr_integrated_reflections
 
             # The output reflections have a filename appended with '_corrected'.
             output_reflections = rescale_dac.reflections_filename.replace(

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -378,8 +378,14 @@ class DialsIntegrater(Integrater):
         # correct for the attenuation of the incident and diffracted beams by the
         # diamond anvils.
         if PhilIndex.params.dials.high_pressure.correct:
+            Chatter.write(
+                "Rescaling integrated reflections for attenuation in the "
+                "diamond anvil cell."
+            )
+
             params = PhilIndex.params.dials.high_pressure
             rescale_dac = _rescale_dac()
+            rescale_dac.clear_command_line()
 
             # Take the filenames of the last integration step as input.
             rescale_dac.experiments_filename = self._intgr_experiments_filename

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -255,6 +255,15 @@ class DialsIntegrater(Integrater):
             integrate.set_d_min(PhilIndex.params.dials.integrate.d_min)
         else:
             integrate.set_d_min(self._intgr_reso_high)
+
+        # Options for profile modelling.
+        high_pressure = PhilIndex.params.dials.high_pressure.correction
+        min_spots_per_degree = PhilIndex.params.dials.integrate.min_spots.per_degree
+        min_spots_overall = PhilIndex.params.dials.integrate.min_spots.overall
+        integrate.set_profile_params(
+            min_spots_per_degree, min_spots_overall, high_pressure
+        )
+
         pname, xname, dname = self.get_integrater_project_info()
         sweep = self.get_integrater_sweep_name()
         FileHandler.record_log_file(
@@ -289,6 +298,12 @@ class DialsIntegrater(Integrater):
                         start - self.get_matching_images()[0],
                         stop - self.get_matching_images()[0],
                     )
+
+                # Options for profile modelling.
+                integrate.set_profile_params(
+                    min_spots_per_degree, min_spots_overall, high_pressure
+                )
+
                 integrate.set_reflections_per_degree(1000)
                 integrate.run()
 
@@ -377,7 +392,7 @@ class DialsIntegrater(Integrater):
         # If running in high-pressure mode, run dials.rescale_diamond_anvil_cell to
         # correct for the attenuation of the incident and diffracted beams by the
         # diamond anvils.
-        if PhilIndex.params.dials.high_pressure.correct:
+        if PhilIndex.params.dials.high_pressure.correction:
             Chatter.write(
                 "Rescaling integrated reflections for attenuation in the "
                 "diamond anvil cell."

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -399,6 +399,7 @@ class DialsIntegrater(Integrater):
             rescale_dac.set_working_directory(self.get_working_directory())
             auto_logfiler(rescale_dac)
             rescale_dac()
+            self._intgr_integrated_reflections = output_reflections
 
         if self._output_format == "hkl":
             exporter = self.ExportMtz()

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -382,11 +382,11 @@ class DialsIntegrater(Integrater):
             rescale_dac = _rescale_dac()
 
             # Take the filenames of the last integration step as input.
-            rescale_dac.experiments_filename = self._intgr_experiments_filename
-            rescale_dac.reflections_filename = self._intgr_integrated_filename
+            rescale_dac.experiments_filename = self.get_integrated_experiments()
+            rescale_dac.reflections_filename = self.get_integrated_reflections()
 
             # The output reflections have a filename appended with '_corrected'.
-            output_reflections = self._intgr_integrated_filename.replace(
+            output_reflections = rescale_dac.reflections_filename.replace(
                 ".refl", "_corrected.refl"
             )
             rescale_dac.output_reflections_filename = output_reflections

--- a/Schema/__init__.py
+++ b/Schema/__init__.py
@@ -72,8 +72,10 @@ def load_imagesets(
         )
         scan_tolerance = params.input.tolerance.scan.oscillation
 
+        # If diamond anvil cell data, always use dynamic shadowing
+        high_pressure = PhilIndex.params.dials.high_pressure.correction
         format_kwargs = {
-            "dynamic_shadowing": params.input.format.dynamic_shadowing,
+            "dynamic_shadowing": params.input.format.dynamic_shadowing or high_pressure,
             "multi_panel": params.input.format.multi_panel,
         }
 

--- a/Wrappers/Dials/Integrate.py
+++ b/Wrappers/Dials/Integrate.py
@@ -96,9 +96,15 @@ def Integrate(DriverType=None):
             # If using a diamond anvil cell, and unless the user specifies otherwise,
             if high_pressure:
                 # don't impose a minimum number of reflections per degree,
-                self._min_spots_per_degree = min_spots_per_degree or 0
+                if min_spots_per_degree:
+                    self._min_spots_per_degree = min_spots_per_degree
+                else:
+                    self._min_spots_per_degree = 0
                 # and use a reduced minimum number of reflections overall.
-                self._min_spots_overall = min_spots_overall or 10
+                if min_spots_overall:
+                    self._min_spots_overall = min_spots_overall
+                else:
+                    self._min_spots_overall = 10
             # Otherwise use user-specified values or defaults.
             else:
                 self._min_spots_per_degree = min_spots_per_degree

--- a/Wrappers/Dials/Integrate.py
+++ b/Wrappers/Dials/Integrate.py
@@ -96,9 +96,7 @@ def Integrate(DriverType=None):
                 # don't impose a minimum number of reflections per degree,
                 self._min_spots_per_degree = min_spots_per_degree or 0
                 # and use a reduced minimum number of reflections overall.
-                self._min_spots_overall = (
-                    min_spots_overall if min_spots_overall is not None else 10
-                )
+                self._min_spots_overall = min_spots_overall or 10
             # Otherwise use user-specified values or defaults.
             else:
                 self._min_spots_per_degree = min_spots_per_degree

--- a/Wrappers/Dials/anvil_correction.py
+++ b/Wrappers/Dials/anvil_correction.py
@@ -1,11 +1,10 @@
 """
-Provide a wrapper for dials.rescale_diamond_anvil_cell.
+Provide a wrapper for dials.anvil_correction.
 
 When performing a high-pressure data collection using a diamond anvil pressure cell,
 the incident and diffracted beams are attenuated in passing through the anvils,
-adversely affecting the scaling statistics.  dials.rescale_diamond_anvil_cell
-provides a correction to the integrated intensities before symmetry determination and
-scaling.
+adversely affecting the scaling statistics.  dials.anvil_correction provides a
+correction to the integrated intensities before symmetry determination and scaling.
 
 This wrapper is intended for use in the _integrate_finish step of the DialsIntegrater.
 """
@@ -28,12 +27,12 @@ def rescale_dac(driver_type=None):
     driver_instance = DriverFactory.Driver(driver_type)
 
     class RescaleDACWrapper(driver_instance.__class__):
-        """Wrap dials.rescale_diamond_anvil_cell."""
+        """Wrap dials.anvil_correction."""
 
         def __init__(self):
             super(RescaleDACWrapper, self).__init__()
 
-            self.set_executable("dials.rescale_diamond_anvil_cell")
+            self.set_executable("dials.anvil_correction")
 
             # Input and output files.
             # None is a valid value only for the output experiment list filename.
@@ -42,13 +41,13 @@ def rescale_dac(driver_type=None):
             self.output_experiments_filename = None  # type: Optional[str]
             self.output_reflections_filename = None  # type: Optional[str]
 
-            # Parameters to pass to dials.rescale_diamond_anvil_cell
+            # Parameters to pass to dials.anvil_correction
             self.density = None  # type: Optional[SupportsFloat]
             self.thickness = None  # type: Optional[SupportsFloat]
             self.normal = None  # type: Optional[Tuple[3 * (SupportsFloat,)]]
 
         def __call__(self):
-            """Run dials.rescale_diamond_anvil_cell if the parameters are valid."""
+            """Run dials.anvil_correction if the parameters are valid."""
             # We should only start if the properties have been set.
             assert self.experiments_filenames
             assert self.reflections_filenames

--- a/Wrappers/Dials/anvil_correction.py
+++ b/Wrappers/Dials/anvil_correction.py
@@ -3,7 +3,7 @@ Provide a wrapper for dials.anvil_correction.
 
 When performing a high-pressure data collection using a diamond anvil pressure cell,
 the incident and diffracted beams are attenuated in passing through the anvils,
-adversely affecting the scaling statistics.  dials.anvil_correction provides a
+adversely affecting the scaling statistics. dials.anvil_correction provides a
 correction to the integrated intensities before symmetry determination and scaling.
 
 This wrapper is intended for use in the _integrate_finish step of the DialsIntegrater.

--- a/Wrappers/Dials/anvil_correction.py
+++ b/Wrappers/Dials/anvil_correction.py
@@ -46,7 +46,7 @@ def rescale_dac(driver_type=None):
             self.thickness = None  # type: Optional[SupportsFloat]
             self.normal = None  # type: Optional[Tuple[3 * (SupportsFloat,)]]
 
-        def __call__(self):
+        def run(self):
             """Run dials.anvil_correction if the parameters are valid."""
             # We should only start if the properties have been set.
             assert self.experiments_filenames
@@ -56,6 +56,8 @@ def rescale_dac(driver_type=None):
             assert self.density
             assert self.thickness
             assert self.normal
+
+            self.clear_command_line()
 
             self.add_command_line(self.experiments_filenames)
             self.add_command_line(self.reflections_filenames)

--- a/Wrappers/Dials/rescale_diamond_anvil_cell.py
+++ b/Wrappers/Dials/rescale_diamond_anvil_cell.py
@@ -1,0 +1,126 @@
+"""
+Provide a wrapper for dials.rescale_diamond_anvil_cell.
+
+When performing a high-pressure data collection using a diamond anvil pressure cell,
+the incident and diffracted beams are attenuated in passing through the anvils,
+adversely affecting the scaling statistics.  dials.rescale_diamond_anvil_cell
+provides a correction to the integrated intensities before symmetry determination and
+scaling.
+
+This wrapper is intended for use in the _integrate_finish step of the DialsIntegrater.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from xia2.Driver.DriverFactory import DriverFactory
+
+import os
+
+
+def rescale_dac(driver_type=None):
+    """A factory for RescaleDACWrapper classes."""
+
+    driver_instance = DriverFactory.Driver(driver_type)
+
+    class RescaleDACWrapper(driver_instance.__class__):
+        """Wrap dials.rescale_diamond_anvil_cell."""
+
+        def __init__(self):
+            super(RescaleDACWrapper, self).__init__()
+
+            self.set_executable("dials.rescale_diamond_anvil_cell")
+
+            # Input and output files.  None is a valid value for the output experiments.
+            self._experiments_filename = None
+            self._reflections_filename = None
+            self._output_experiments_filename = None
+            self._output_reflections_filename = None
+
+            # Parameters to pass to dials.rescale_diamond_anvil_cell
+            self._density = None
+            self._thickness = None
+            self._normal = None
+
+        @property
+        def experiments_filename(self):
+            return self._experiments_filename
+
+        @experiments_filename.setter
+        def experiments_filename(self, filename):
+            self.add_command_line("%s" % filename)
+            self._experiments_filename = filename
+
+        @property
+        def reflections_filename(self):
+            return self._reflections_filename
+
+        @reflections_filename.setter
+        def reflections_filename(self, filename):
+            self.add_command_line("%s" % filename)
+            self._experiments_filename = filename
+
+        @property
+        def output_experiments_filename(self):
+            return self._output_experiments_filename
+
+        @output_experiments_filename.setter
+        def output_experiments_filename(self, filename):
+            self.add_command_line("output.experiments=%s" % filename)
+            self._output_experiments_filename = filename
+
+        @property
+        def output_reflections_filename(self):
+            return self._output_reflections_filename
+
+        @output_reflections_filename.setter
+        def output_reflections_filename(self, filename):
+            self.add_command_line("output.reflections=%s" % filename)
+            self._output_reflections_filename = filename
+
+        @property
+        def density(self):
+            return self._density
+
+        @density.setter
+        def density(self, density):
+            self.add_command_line("anvil.density=%s" % density)
+            self._density = density
+
+        @property
+        def thickness(self):
+            return self._thickness
+
+        @thickness.setter
+        def thickness(self, thickness):
+            self.add_command_line("anvil.thickness=" % thickness)
+            self._thickness = thickness
+
+        @property
+        def normal(self):
+            return self._normal
+
+        @normal.setter
+        def normal(self, normal):
+            self.add_command_line("anvil.normal=%s" % normal)
+            self._normal = normal
+
+        def __call__(self):
+            """Run dials.rescale_diamond_anvil_cell if the parameters are valid."""
+            self.clear_command_line()
+
+            # We should only start if the properties have been set.
+            assert self.experiments_filename
+            assert self.reflections_filename
+            # None is a valid value for the output experiment list filename.
+            assert self.output_reflections_filename
+            assert self.density
+            assert self.thickness
+            assert self.normal
+
+            self.start()
+            self.close_wait()
+            self.check_for_errors()
+
+            assert os.path.exists(self._output_reflections_filename)
+
+    return RescaleDACWrapper()

--- a/Wrappers/Dials/rescale_diamond_anvil_cell.py
+++ b/Wrappers/Dials/rescale_diamond_anvil_cell.py
@@ -57,7 +57,7 @@ def rescale_dac(driver_type=None):
         @reflections_filename.setter
         def reflections_filename(self, filename):
             self.add_command_line("%s" % filename)
-            self._experiments_filename = filename
+            self._reflections_filename = filename
 
         @property
         def output_experiments_filename(self):
@@ -92,7 +92,7 @@ def rescale_dac(driver_type=None):
 
         @thickness.setter
         def thickness(self, thickness):
-            self.add_command_line("anvil.thickness=" % thickness)
+            self.add_command_line("anvil.thickness=%s" % thickness)
             self._thickness = thickness
 
         @property
@@ -101,13 +101,11 @@ def rescale_dac(driver_type=None):
 
         @normal.setter
         def normal(self, normal):
-            self.add_command_line("anvil.normal=%s" % normal)
+            self.add_command_line("anvil.normal=%s,%s,%s" % tuple(normal))
             self._normal = normal
 
         def __call__(self):
             """Run dials.rescale_diamond_anvil_cell if the parameters are valid."""
-            self.clear_command_line()
-
             # We should only start if the properties have been set.
             assert self.experiments_filename
             assert self.reflections_filename

--- a/newsfragments/396.feature
+++ b/newsfragments/396.feature
@@ -1,0 +1,4 @@
+Improve handling of diamond anvil cell data.  When calling xia2 with `high_pressure.correct=True`:
+- 'Dynamic shadowing' is enabled, to mask out the regions shadowed by the cell body.
+- The minimum observation counts for profile modelling are relaxed — the defaults are unrealistic in the case of small diamond anvil cell data on small-molecule materials, since there are far fewer spots than the DIALS profile modelling expects, based on the norm in MX.  This had been a frequent cause of frustration when processing small-molecule data with xia2.
+- X-ray absorption in the diamond anvils is automatically corrected for using `dials.rescale_diamond_anvil_cell`.

--- a/newsfragments/396.feature
+++ b/newsfragments/396.feature
@@ -1,4 +1,4 @@
 Improve handling of diamond anvil cell data.  When calling xia2 with `high_pressure.correct=True`:
 - 'Dynamic shadowing' is enabled, to mask out the regions shadowed by the cell body.
 - The minimum observation counts for profile modelling are relaxed — the defaults are unrealistic in the case of small diamond anvil cell data on small-molecule materials, since there are far fewer spots than the DIALS profile modelling expects, based on the norm in MX.  This had been a frequent cause of frustration when processing small-molecule data with xia2.
-- X-ray absorption in the diamond anvils is automatically corrected for using `dials.rescale_diamond_anvil_cell`.
+- X-ray absorption in the diamond anvils is automatically corrected for using `dials.anvil_correction`.

--- a/newsfragments/396.feature
+++ b/newsfragments/396.feature
@@ -1,4 +1,4 @@
-Improve handling of diamond anvil cell data.  When calling xia2 with `high_pressure.correct=True`:
+Improve handling of diamond anvil cell data.  When calling xia2 with `high_pressure.correction=True`:
 - 'Dynamic shadowing' is enabled, to mask out the regions shadowed by the cell body.
-- The minimum observation counts for profile modelling are relaxed — the defaults are unrealistic in the case of small diamond anvil cell data on small-molecule materials, since there are far fewer spots than the DIALS profile modelling expects, based on the norm in MX.  This had been a frequent cause of frustration when processing small-molecule data with xia2.
+- The minimum observation counts for profile modelling are relaxed — the defaults are unrealistic in the case of a small data set from a small-molecule material in a diamond anvil cell.  In such cases, there are far fewer spots than the DIALS profile modelling expects, based on the norm in MX.  This had been a frequent cause of frustration when processing small-molecule data with xia2.
 - X-ray absorption in the diamond anvils is automatically corrected for using `dials.anvil_correction`.


### PR DESCRIPTION
- Always use dynamic shadowing for diamond anvil cell data.
- Relax the minimum observation counts for profile modelling, which are unrealistic in the case of small diamond anvil cell data on small-molecule materials, since there are far fewer spots than the DIALS profile modelling expects, based on the norm in MX.
- Allow automatic correction of absorption in the diamond anvils of a pressure cell using `dials.rescale_diamond_anvil_cell`.

Depends on dials/dials#1090.

This obviously need squashing and merging.  Enjoy the history of my pre-Christmas pain.