### PR TITLE
Rename xia2.error to xia2-error.txt

### DIFF
--- a/Test/regression/__init__.py
+++ b/Test/regression/__init__.py
@@ -26,10 +26,10 @@ def check_result(
     ccp4 = ccp4["version"]
     xds = xds["version"] if xds else 0
 
-    error_file = tmpdir / "xia2.error"
+    error_file = tmpdir / "xia2-error.txt"
     if error_file.check():
         print(error_file.read())
-        return False, "xia2.error present after execution"
+        return False, "xia2-error.txt present after execution"
 
     if result["stderr"]:
         return False, "xia2 terminated with output to STDERR:\n" + result["stderr"]

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -13,7 +13,7 @@ def run():
     try:
         check_environment()
     except Exception as e:
-        with open("xia2.error", "w") as fh:
+        with open("xia2-error.txt", "w") as fh:
             traceback.print_exc(file=fh)
         Chatter.write('Status: error "%s"' % str(e))
 
@@ -31,7 +31,7 @@ def run():
         Chatter.write("Status: normal termination")
 
     except Exception as e:
-        with open(os.path.join(wd, "xia2.error"), "w") as fh:
+        with open(os.path.join(wd, "xia2-error.txt"), "w") as fh:
             traceback.print_exc(file=fh)
         Chatter.write('Status: error "%s"' % str(e))
 

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -13,7 +13,7 @@ def run():
     try:
         check_environment()
     except Exception as e:
-        with open("xia2.error", "w") as fh:
+        with open("xia2-error.txt", "w") as fh:
             traceback.print_exc(file=fh)
         Chatter.write('Status: error "%s"' % str(e))
         sys.exit(1)
@@ -31,7 +31,7 @@ def run():
         Chatter.write("Status: normal termination")
 
     except Exception as e:
-        with open(os.path.join(wd, "xia2.error"), "w") as fh:
+        with open(os.path.join(wd, "xia2-error.txt"), "w") as fh:
             traceback.print_exc(file=fh)
         Chatter.write('Status: error "%s"' % str(e))
         sys.exit(1)

--- a/command_line/rescale.py
+++ b/command_line/rescale.py
@@ -22,7 +22,7 @@ def run():
     try:
         check_environment()
     except Exception as e:
-        with open("xia2.error", "w") as fh:
+        with open("xia2-error.txt", "w") as fh:
             traceback.print_exc(file=fh)
         Chatter.write('Status: error "%s"' % str(e))
 

--- a/command_line/strategy.py
+++ b/command_line/strategy.py
@@ -15,7 +15,7 @@ def run():
     try:
         check_environment()
     except Exception as e:
-        with open("xia2.error", "w") as fh:
+        with open("xia2-error.txt", "w") as fh:
             traceback.print_exc(file=fh)
         Chatter.write('Status: error "%s"' % str(e))
 
@@ -200,7 +200,7 @@ def run():
             json.dump(results_all, f, indent=2)
 
     except Exception as e:
-        with open(os.path.join(cwd, "xia2.error"), "w") as fh:
+        with open(os.path.join(cwd, "xia2-error.txt"), "w") as fh:
             traceback.print_exc(file=fh)
         Chatter.write('Status: error "%s"' % str(e))
     os.chdir(cwd)

--- a/command_line/xia2_main.py
+++ b/command_line/xia2_main.py
@@ -322,11 +322,11 @@ def run():
     try:
         check_environment()
     except Exception as e:
-        traceback.print_exc(file=open("xia2.error", "w"))
+        traceback.print_exc(file=open("xia2-error.txt", "w"))
         Debug.write(traceback.format_exc(), strip=False)
         Chatter.write("Error setting up xia2 environment: %s" % str(e))
         Chatter.write(
-            "Please send the contents of xia2.txt, xia2.error and xia2-debug.txt to:"
+            "Please send the contents of xia2.txt, xia2-error.txt and xia2-debug.txt to:"
         )
         Chatter.write("xia2.support@gmail.com")
         sys.exit(1)
@@ -345,12 +345,12 @@ def run():
         Chatter.write("Error: %s" % str(s))
         sys.exit(1)
     except Exception as e:
-        with open(os.path.join(wd, "xia2.error"), "w") as fh:
+        with open(os.path.join(wd, "xia2-error.txt"), "w") as fh:
             traceback.print_exc(file=fh)
         Debug.write(traceback.format_exc(), strip=False)
         Chatter.write("Error: %s" % str(e))
         Chatter.write(
-            "Please send the contents of xia2.txt, xia2.error and xia2-debug.txt to:"
+            "Please send the contents of xia2.txt, xia2-error.txt and xia2-debug.txt to:"
         )
         Chatter.write("xia2.support@gmail.com")
         sys.exit(1)


### PR DESCRIPTION
It's a text file, so call it .txt. This will facilitate viewing the contents of the file in phone/web email clients.