### PR TITLE
refactor frenchwilson calling code

### DIFF
--- a/Modules/CctbxFrenchWilson.py
+++ b/Modules/CctbxFrenchWilson.py
@@ -1,90 +1,63 @@
 from __future__ import absolute_import, division, print_function
 
-import sys
+import logging
 
-import iotbx.phil
 from iotbx.reflection_file_reader import any_reflection_file
-from libtbx.phil import command_line
 from mmtbx.scaling import data_statistics
+from six.moves import StringIO
 
-master_phil_scope = iotbx.phil.parse(
-    """\
-hklout = truncate.mtz
-  .type = path
-anomalous = False
-  .type = bool
-include scope cctbx.french_wilson.master_phil
-""",
-    process_includes=True,
-)
+fwlog = logging.getLogger("xia2.Modules.CctbxFrenchWilson")
 
 
-class french_wilson(object):
-    def __init__(self, mtz_file, params=None):
-        print("Reading reflections from %s" % mtz_file)
+def do_french_wilson(mtz_file, hklout, anomalous=False):
+    fwlog.info("Reading reflections from %s", mtz_file)
 
-        result = any_reflection_file(mtz_file)
-        assert result.file_type() == "ccp4_mtz"
-        mtz_object = result.file_content()
-        mtz_object.show_summary()
+    result = any_reflection_file(mtz_file)
+    assert result.file_type() == "ccp4_mtz"
 
-        for ma in result.as_miller_arrays(merge_equivalents=False):
-            if params.anomalous and ma.info().labels == [
-                "I(+)",
-                "SIGI(+)",
-                "I(-)",
-                "SIGI(-)",
-            ]:
-                assert ma.anomalous_flag()
-                intensities = (
-                    ma.merge_equivalents().array()
-                )  # XXX why is this necessary?
-            elif ma.info().labels == ["IMEAN", "SIGIMEAN"]:
-                assert not ma.anomalous_flag()
-                intensities = ma
-            else:
-                intensities = None
+    mtz_object = result.file_content()
+    output = StringIO()
+    mtz_object.show_summary(out=output)
 
-            if intensities:
-                assert intensities.is_xray_intensity_array()
-                amplitudes = intensities.french_wilson(params=params)
-                assert amplitudes.is_xray_amplitude_array()
+    for ma in result.as_miller_arrays(merge_equivalents=False):
+        if anomalous and ma.info().labels == [
+            "I(+)",
+            "SIGI(+)",
+            "I(-)",
+            "SIGI(-)",
+        ]:
+            assert ma.anomalous_flag()
+            intensities = ma.merge_equivalents().array()  # XXX why is this necessary?
+        elif ma.info().labels == ["IMEAN", "SIGIMEAN"]:
+            assert not ma.anomalous_flag()
+            intensities = ma
+        else:
+            intensities = None
 
-                dano = None
-                if amplitudes.anomalous_flag():
-                    dano = amplitudes.anomalous_differences()
+        if intensities:
+            assert intensities.is_xray_intensity_array()
+            amplitudes = intensities.french_wilson(log=output)
+            assert amplitudes.is_xray_amplitude_array()
 
-                if not intensities.space_group().is_centric():
-                    merged_intensities = intensities.merge_equivalents().array()
-                    wilson_scaling = data_statistics.wilson_scaling(
-                        miller_array=merged_intensities, n_residues=200
-                    )  # XXX default n_residues?
-                    wilson_scaling.show()
-                    print()
+            dano = None
+            if amplitudes.anomalous_flag():
+                dano = amplitudes.anomalous_differences()
 
-                mtz_dataset = mtz_object.crystals()[1].datasets()[0]
-                mtz_dataset.add_miller_array(amplitudes, column_root_label="F")
-                if dano is not None:
-                    mtz_dataset.add_miller_array(
-                        dano, column_root_label="DANO", column_types="DQ"
-                    )
-        mtz_object.add_history("cctbx.french_wilson analysis")
-        print("Writing reflections to %s" % (params.hklout))
-        mtz_object.show_summary()
-        mtz_object.write(params.hklout)
+            if not intensities.space_group().is_centric():
+                merged_intensities = intensities.merge_equivalents().array()
+                wilson_scaling = data_statistics.wilson_scaling(
+                    miller_array=merged_intensities, n_residues=200
+                )  # XXX default n_residues?
+                wilson_scaling.show(out=output)
 
-
-def run(args):
-    cmd_line = command_line.argument_interpreter(master_params=master_phil_scope)
-    working_phil, args = cmd_line.process_and_fetch(
-        args=args, custom_processor="collect_remaining"
-    )
-    working_phil.show()
-    params = working_phil.extract()
-    assert len(args) == 1
-
-    french_wilson(args[0], params=params)
-
-
-if __name__ == "__main__":
-    run(sys.argv[1:])
+            mtz_dataset = mtz_object.crystals()[1].datasets()[0]
+            mtz_dataset.add_miller_array(amplitudes, column_root_label="F")
+            if dano is not None:
+                mtz_dataset.add_miller_array(
+                    dano, column_root_label="DANO", column_types="DQ"
+                )
+    mtz_object.add_history("cctbx.french_wilson analysis")
+    mtz_object.show_summary(out=output)
+    fwlog.info("Writing reflections to %s", hklout)
+    mtz_object.write(hklout)
+    return output.getvalue()

--- a/Test/Modules/test_french_wilson.py
+++ b/Test/Modules/test_french_wilson.py
@@ -1,16 +1,17 @@
 from __future__ import absolute_import, division, print_function
 
-import os
-
+import xia2.Modules.CctbxFrenchWilson
 from iotbx.reflection_file_reader import any_reflection_file
-from xia2.Modules import CctbxFrenchWilson
 
 
-def test_french_wilson(dials_data):
+def test_french_wilson(dials_data, tmpdir):
     scaled_mtz = dials_data("x4wide_processed").join("AUTOMATIC_DEFAULT_scaled.mtz")
-    CctbxFrenchWilson.run([scaled_mtz.strpath, "anomalous=True"])
-    assert os.path.exists("truncate.mtz")
-    result = any_reflection_file("truncate.mtz")
+    truncated_mtz = tmpdir.join("truncate.mtz")
+    xia2.Modules.CctbxFrenchWilson.do_french_wilson(
+        scaled_mtz.strpath, truncated_mtz.strpath, anomalous=True
+    )
+    assert truncated_mtz.check()
+    result = any_reflection_file(truncated_mtz.strpath)
     assert result.file_type() == "ccp4_mtz"
     all_labels = [
         ma.info().labels for ma in result.as_miller_arrays(merge_equivalents=False)

--- a/Wrappers/CCP4/Truncate.py
+++ b/Wrappers/CCP4/Truncate.py
@@ -14,13 +14,13 @@ from xia2.Wrappers.XIA.FrenchWilson import FrenchWilson
 def Truncate(DriverType=None):
     """A factory for TruncateWrapper classes."""
 
-    DriverInstance = DriverFactory.Driver(DriverType)
-    CCP4DriverInstance = DecoratorFactory.Decorate(DriverInstance, "ccp4")
-
     if PhilIndex.params.ccp4.truncate.program == "ctruncate":
         return Ctruncate(DriverType)
     elif PhilIndex.params.ccp4.truncate.program == "cctbx":
         return FrenchWilson(DriverType)
+
+    DriverInstance = DriverFactory.Driver(DriverType)
+    CCP4DriverInstance = DecoratorFactory.Decorate(DriverInstance, "ccp4")
 
     class TruncateWrapper(CCP4DriverInstance.__class__):
         """A wrapper for Truncate, using the CCP4-ified Driver."""


### PR DESCRIPTION
Turn the object with a single method writing to stdout and taking a 3-element PHIL object
into a normal function with 3 parameters returning a string.

Change the wrapper to then not run this function in a subprocess.

Regression testing shows a tolerance warning, but I think that was already there.