### PR TITLE
Be more explicit when setting model options for dials.scale

### DIFF
--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -401,10 +401,10 @@ dials
     .expert_level = 1
     .short_caption = "Scaling"
   {
-    model = *auto physical array kb
+    model = *auto physical array KB
       .type = choice
       .help = "Choice of scaling model parameterisation to apply"
-    rotation_spacing = 15.0
+    rotation_spacing = None
       .type = float
       .help = "Parameter spacing for scale (rotation) term"
     Bfactor = True
@@ -414,7 +414,7 @@ dials
       .type = bool
       .help = "Include an absorption correction in scaling"
     physical_model {
-      Bfactor_spacing = 20.0
+      Bfactor_spacing = None
         .type = float
         .help = "Parameter spacing for B-factor correction"
       lmax = 4
@@ -425,7 +425,7 @@ dials
       resolution_bins = 10
         .type = int(value_min=1)
         .help = "Number of bins to parameterise decay component"
-      absorption_bins = 3
+      absorption_bins = 5
         .type = int(value_min=1)
         .help = "Number of bins in each dimension (applied to both x and y) for " \
                 "binning the detector position for the absorption term of the " \

--- a/Wrappers/Dials/Scale.py
+++ b/Wrappers/Dials/Scale.py
@@ -123,6 +123,9 @@ def DialsScale(DriverType=None, decay_correction=None):
         def set_decay_bins(self, n_bins):
             self._n_resolution_bins = n_bins
 
+        def set_array_absorption_bins(self, n_bins):
+            self._n_absorption_bins = n_bins
+
         def set_min_partiality(self, min_partiality):
             self._min_partiality = min_partiality
 
@@ -230,28 +233,46 @@ def DialsScale(DriverType=None, decay_correction=None):
             elif self._intensities == "profile":
                 self.add_command_line("intensity_choice=profile")
 
-            assert self._model is not None
-            self.add_command_line("model=%s" % self._model)
+            # Handle all model options. Model can be none - would trigger auto
+            # models in dials.scale.
+            if self._model is not None:
+                self.add_command_line("model=%s" % self._model)
+                # Decay correction can refer to any model (physical, array, KB)
+                if self._bfactor:
+                    self.add_command_line("%s.decay_correction=True" % self._model)
+                else:
+                    self.add_command_line("%s.decay_correction=False" % self._model)
 
-            if self._bfactor:
-                self.add_command_line("%s.decay_correction=True" % self._model)
-
-            if self._model != "KB":
+            if self._model == "physical" or self._model == "array":
+                # These options can refer to array or physical model
                 if self._absorption_correction:
                     self.add_command_line("%s.absorption_correction=True" % self._model)
+                else:
+                    self.add_command_line(
+                        "%s.absorption_correction=False" % self._model
+                    )
                 if self._bfactor and self._brotation is not None:
                     self.add_command_line(
                         "%s.decay_interval=%g" % (self._model, self._brotation)
                     )
 
+            # Option only relevant for spherical harmonic absorption in physical model.
+            if (
+                self._model == "physical"
+                and self._absorption_correction
+                and self._lmax is not None
+            ):
+                self.add_command_line("%s.lmax=%i" % (self._model, self._lmax))
+
+            # 'Spacing' i.e. scale interval only relevant to physical model.
+            if self._model == "physical" and self._spacing:
+                self.add_command_line(
+                    "%s.scale_interval=%g" % (self._model, self._spacing)
+                )
+
             self.add_command_line("full_matrix=%s" % self._full_matrix)
-            if self._spacing:
-                self.add_command_line("scale_interval=%g" % self._spacing)
             self.add_command_line("error_model=%s" % self._error_model)
             self.add_command_line("outlier_rejection=%s" % self._outlier_rejection)
-
-            if self._absorption_correction and self._lmax is not None:
-                self.add_command_line("lmax=%i" % self._lmax)
 
             if self._min_partiality is not None:
                 self.add_command_line("min_partiality=%s" % self._min_partiality)


### PR DESCRIPTION
Currently, the dials scaling model options are not being set very cleanly. This seems to be causing an issue for xia2.multiplex - where for narrow wedge scans < 15 degrees, only two parameters are used for scale and decay components, but an absorption surface is used (24 params), which is the opposite default behaviour to dials.scale. There were also lots of Phil options which probably werent working as expected.
E.g. This is the current model parameterisation (+ absorption surface)

![newplot](https://user-images.githubusercontent.com/30625594/74546735-f419f880-4f42-11ea-9a15-4b5240288d6d.png)

This PR updates things to follow more closely the default dials behaviour while preserving the current xia2 Phil options. This restores behaviour expected for dials.scale, giving the following model parameterisation (no absorption surface), which I assert is generally more useful for multi-crystal data:

![newplot (2)](https://user-images.githubusercontent.com/30625594/74546869-29264b00-4f43-11ea-878e-6799de2ff807.png)
