### PR TITLE
Output .sca files in dials pipeline

### DIFF
--- a/Test/regression/test_mad_example.py
+++ b/Test/regression/test_mad_example.py
@@ -13,12 +13,6 @@ expected_data_files = [
     "AUTOMATIC_DEFAULT_scaled_unmerged_WAVE2.mtz",
 ]
 
-expected_data_files_nosca = [
-    "AUTOMATIC_DEFAULT_free.mtz",
-    "AUTOMATIC_DEFAULT_scaled_unmerged_WAVE1.mtz",
-    "AUTOMATIC_DEFAULT_scaled_unmerged_WAVE2.mtz",
-]
-
 
 def test_dials(regression_test, dials_data, tmpdir, ccp4):
     command_line = [
@@ -36,7 +30,7 @@ def test_dials(regression_test, dials_data, tmpdir, ccp4):
         result,
         tmpdir,
         ccp4,
-        expected_data_files=expected_data_files_nosca,
+        expected_data_files=expected_data_files,
     )
     assert success, issues
 

--- a/Test/regression/test_small_molecule.py
+++ b/Test/regression/test_small_molecule.py
@@ -48,10 +48,7 @@ def test_dials(regression_test, dials_data, tmpdir, ccp4):
         result,
         tmpdir,
         ccp4,
-        expected_data_files=[
-            "AUTOMATIC_DEFAULT_scaled.mtz",
-            "AUTOMATIC_DEFAULT_scaled_unmerged.mtz",
-        ],
+        expected_data_files=expected_data_files,
     )
     assert success, issues
 


### PR DESCRIPTION
These were removed in DIALS2.0 as a side effect of the change to using the dials(-full) pipeline.
Generate them once more.