### PR TITLE
Reindex to input spacegroup, not pointgroup

### DIFF
--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -217,15 +217,14 @@ class DialsScaler(Scaler):
         return need_to_return
 
     def _input_pointgroup_scale_prepare(self):
-        # is this function completely pointless?
-        # ---------- REINDEX ALL DATA TO CORRECT POINTGROUP ----------
-        ####Redoing batches only seems to be in multi_sweep_idxing for CCP4A
+        pointgroup = self._scalr_input_pointgroup
         if self._scalr_input_spacegroup:
             self._scalr_likely_spacegroups = [self._scalr_input_spacegroup]
-        logger.debug("Using input pointgroup: %s", self._scalr_input_pointgroup)
+            pointgroup = self._scalr_input_spacegroup
+        logger.debug("Using input pointgroup: %s", pointgroup)
         for epoch in self._sweep_handler.get_epochs():
             si = self._sweep_handler.get_sweep_information(epoch)
-            self._helper.reindex_jiffy(si, self._scalr_input_pointgroup, "h,k,l")
+            self._helper.reindex_jiffy(si, pointgroup, "h,k,l")
 
     def _standard_scale_prepare(self):
         pointgroups = {}

--- a/Test/regression/__init__.py
+++ b/Test/regression/__init__.py
@@ -6,6 +6,9 @@ import re
 import six
 import warnings
 
+from cctbx import sgtbx
+from iotbx.reflection_file_reader import any_reflection_file
+
 import xia2.Test.regression
 
 default_data_files = [
@@ -21,7 +24,13 @@ class Xia2RegressionToleranceWarning(UserWarning):
 
 
 def check_result(
-    test_name, result, tmpdir, ccp4, xds=None, expected_data_files=default_data_files
+    test_name,
+    result,
+    tmpdir,
+    ccp4,
+    xds=None,
+    expected_data_files=default_data_files,
+    expected_space_group=None,
 ):
     ccp4 = ccp4["version"]
     xds = xds["version"] if xds else 0
@@ -214,6 +223,24 @@ def check_result(
     for data_file in expected_data_files:
         if not (tmpdir / "DataFiles" / data_file).check():
             return False, "expected file %s is missing" % data_file
+        if expected_space_group is not None:
+            miller_arrays = any_reflection_file(
+                (tmpdir / "DataFiles" / data_file).strpath
+            ).as_miller_arrays()
+            for ma in miller_arrays:
+                if (
+                    ma.space_group()
+                    != sgtbx.space_group_info(expected_space_group).group()
+                ):
+                    return (
+                        False,
+                        "Unexpected space group %s in %s (expected %s)"
+                        % (
+                            ma.space_group().type().lookup_symbol(),
+                            data_file,
+                            expected_space_group,
+                        ),
+                    )
 
     html_file = "xia2.html"
     if not (tmpdir / html_file).check():

--- a/Test/regression/expected/result.X4_wide.space_group.3dii.7.0.78.0
+++ b/Test/regression/expected/result.X4_wide.space_group.3dii.7.0.78.0
@@ -1,0 +1,22 @@
+Project: AUTOMATIC
+Crystal: DEFAULT
+Sequence length: 0
+Wavelength: NATIVE (0.97950)
+Sweep: SWEEP1
+Files ***
+Images: 20 to 30
+Beam 220.00 212.48 => 219.88 212.57
+Distance 190.18 => 191.73(0.1)
+Date: Thu Jan  1 00:00:00 1970
+For AUTOMATIC/DEFAULT/NATIVE:
+High resolution limit                           1.27(5%)    3.43(10%)    1.27(**)
+Low resolution limit                           14.00(5%)   14.00(**)    1.29(**)
+Completeness                                   51.1(5%)    46.3(5%)    51.7(10)
+Multiplicity                                    1.4(0.2)     1.4(0.2)     1.4(0.2)
+I/sigma                                         5.6(15%)    12.6(**)     1.2(0.3)
+Rmerge(I+/-)                                  0.055(10%)   0.052(10%)   0.683(15%)
+CC half                                       0.994(2%)   0.991(0.2)   0.605(0.2)
+Anomalous completeness                         12.6(2%)    11.4(5%)    13.3(10)
+Anomalous multiplicity                          1.2(0.5)     1.2(0.5)     1.2(0.5)
+Cell:  42.320(0.5%)  42.320(0.5%)  39.650(0.5%)  90.000  90.000  90.000
+Spacegroup: P 4 2 2

--- a/Test/regression/expected/result.X4_wide.space_group.dials-aimless.7.0.78.0
+++ b/Test/regression/expected/result.X4_wide.space_group.dials-aimless.7.0.78.0
@@ -1,0 +1,22 @@
+Project: AUTOMATIC
+Crystal: DEFAULT
+Sequence length: 0
+Wavelength: NATIVE (0.97950)
+Sweep: SWEEP1
+Files ***
+Images: 20 to 30
+Beam 220.00 212.48 => 219.89 212.61
+Distance 190.18 => 192.18(0.1)
+Date: Thu Jan  1 00:00:00 1970
+For AUTOMATIC/DEFAULT/NATIVE:
+High resolution limit                           1.33(5%)    3.60(10%)    1.33(**)
+Low resolution limit                           16.55(5%)   16.56(**)    1.35(**)
+Completeness                                   36.4(5%)    34.0(5%)    35.4(10)
+Multiplicity                                    1.3(0.2)     1.3(0.2)     1.3(0.2)
+I/sigma                                         5.4(15%)    12.3(**)     1.3(0.3)
+Rmerge(I+/-)                                  0.035(10%)   0.016(10%)   0.682(15%)
+CC half                                       0.998(2%)   0.998(0.2)   0.738(0.2)
+Anomalous completeness                          7.6(2%)     6.5(5%)     6.1(10)
+Anomalous multiplicity                          1.1(0.5)     1.2(0.5)     1.1(0.5)
+Cell:  42.406(0.5%)  42.406(0.5%)  39.708(0.5%)  90.000  90.000  90.000
+Spacegroup: P 4 2 2

--- a/Test/regression/expected/result.X4_wide.space_group.dials.7.0.78.0
+++ b/Test/regression/expected/result.X4_wide.space_group.dials.7.0.78.0
@@ -1,0 +1,22 @@
+Project: AUTOMATIC
+Crystal: DEFAULT
+Sequence length: 0
+Wavelength: NATIVE (0.97950)
+Sweep: SWEEP1
+Files ***
+Images: 20 to 30
+Beam 220.00 212.48 => 219.89 212.61
+Distance 190.18 => 192.18(0.1)
+Date: Thu Jan  1 00:00:00 1970
+For AUTOMATIC/DEFAULT/NATIVE:
+High resolution limit                           1.32(5%)    3.58(10%)    1.32(**)
+Low resolution limit                           18.97(5%)   18.97(**)    1.34(**)
+Completeness                                   50.3(5%)    45.7(5%)    48.7(10)
+Multiplicity                                    1.4(0.2)     1.4(0.2)     1.3(0.2)
+I/sigma                                         7.1(15%)    38.4(**)     0.5(0.3)
+Rmerge(I+/-)                                  0.048(10%)   0.028(10%)   0.434(15%)
+CC half                                       0.997(2%)   0.996(0.2)   0.600(0.2)
+Anomalous completeness                         12.6(2%)    12.6(5%)     7.9(10)
+Anomalous multiplicity                          1.2(0.5)     1.2(0.5)     1.1(0.5)
+Cell:  42.410(0.5%)  42.410(0.5%)  39.710(0.5%)  90.000  90.000  90.000
+Spacegroup: P 4 2 2

--- a/Test/regression/test_X4_wide.py
+++ b/Test/regression/test_X4_wide.py
@@ -51,7 +51,8 @@ def test_incompatible_pipeline_scaler(pipeline, scaler, tmpdir, ccp4):
     ) in result.stdout.decode("latin-1")
 
 
-def test_dials_aimless(regression_test, dials_data, tmpdir, ccp4):
+@pytest.mark.parametrize("space_group", [None, "P41212", "P422"])
+def test_dials_aimless(space_group, regression_test, dials_data, tmpdir, ccp4):
     command_line = [
         "xia2",
         "pipeline=dials-aimless",
@@ -61,9 +62,18 @@ def test_dials_aimless(regression_test, dials_data, tmpdir, ccp4):
         "truncate=cctbx",
         dials_data("x4wide").strpath,
     ]
+    if space_group:
+        command_line.append("space_group='%s'" % space_group)
+        expected_space_group = space_group
+    else:
+        expected_space_group = "P41212"
     result = procrunner.run(command_line, working_directory=tmpdir)
     success, issues = xia2.Test.regression.check_result(
-        "X4_wide.dials-aimless", result, tmpdir, ccp4
+        "X4_wide.dials-aimless",
+        result,
+        tmpdir,
+        ccp4,
+        expected_space_group=expected_space_group,
     )
     assert success, issues
 
@@ -87,7 +97,8 @@ def test_dials_aimless_with_dials_pipeline(regression_test, dials_data, tmpdir, 
     assert success, issues
 
 
-def test_dials(regression_test, dials_data, tmpdir, ccp4):
+@pytest.mark.parametrize("space_group", [None, "P41212", "P422"])
+def test_dials(space_group, regression_test, dials_data, tmpdir, ccp4):
     command_line = [
         "xia2",
         "pipeline=dials",
@@ -98,6 +109,11 @@ def test_dials(regression_test, dials_data, tmpdir, ccp4):
         "free_total=1000",
         dials_data("x4wide").strpath,
     ]
+    if space_group:
+        command_line.append("space_group='%s'" % space_group)
+        expected_space_group = space_group
+    else:
+        expected_space_group = "P41212"
     result = procrunner.run(command_line, working_directory=tmpdir)
     print(result)
     success, issues = xia2.Test.regression.check_result(
@@ -109,6 +125,7 @@ def test_dials(regression_test, dials_data, tmpdir, ccp4):
             "AUTOMATIC_DEFAULT_scaled.mtz",
             "AUTOMATIC_DEFAULT_scaled_unmerged.mtz",
         ],
+        expected_space_group=expected_space_group,
     )
     assert success, issues
 
@@ -157,7 +174,8 @@ def test_dials_split(multi_sweep_indexing, regression_test, dials_data, tmpdir, 
     assert success, issues
 
 
-def test_xds(regression_test, dials_data, tmpdir, ccp4, xds):
+@pytest.mark.parametrize("space_group", [None, "P41212", "P422"])
+def test_xds(space_group, regression_test, dials_data, tmpdir, ccp4, xds):
     command_line = [
         "xia2",
         "pipeline=3di",
@@ -166,9 +184,19 @@ def test_xds(regression_test, dials_data, tmpdir, ccp4, xds):
         "read_all_image_headers=False",
         dials_data("x4wide").strpath,
     ]
+    if space_group:
+        command_line.append("space_group='%s'" % space_group)
+        expected_space_group = space_group
+    else:
+        expected_space_group = "P41212"
     result = procrunner.run(command_line, working_directory=tmpdir)
     success, issues = xia2.Test.regression.check_result(
-        "X4_wide.xds", result, tmpdir, ccp4, xds
+        "X4_wide.xds",
+        result,
+        tmpdir,
+        ccp4,
+        xds,
+        expected_space_group=expected_space_group,
     )
     assert success, issues
 

--- a/Test/regression/test_X4_wide.py
+++ b/Test/regression/test_X4_wide.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import itertools
+
 import procrunner
 import pytest
 import xia2.Test.regression
@@ -228,16 +230,13 @@ def test_xds_ccp4a_split(regression_test, dials_data, tmpdir, ccp4, xds):
 
 @pytest.mark.parametrize(
     "pipeline,space_group",
-    (
-        (pipeline, space_group)
-        for pipeline in ("dials", "dials-aimless", "3dii")
-        for space_group in ("P41212", "P422")
-    ),
+    itertools.product(("dials", "dials-aimless", "3dii"), ("P41212", "P422")),
 )
 def test_space_group(pipeline, space_group, regression_test, dials_data, tmpdir, ccp4):
     command_line = [
         "xia2",
         "pipeline=%s" % pipeline,
+        "space_group=%s" % space_group,
         "nproc=1",
         "trust_beam_centre=True",
         "read_all_image_headers=False",
@@ -245,15 +244,12 @@ def test_space_group(pipeline, space_group, regression_test, dials_data, tmpdir,
         "free_total=1000",
         "image=%s" % dials_data("x4wide").join("X4_wide_M1S4_2_0001.cbf:20:30"),
     ]
-    command_line.append("space_group='%s'" % space_group)
-    expected_space_group = space_group
     result = procrunner.run(command_line, working_directory=tmpdir)
-    print(result)
     success, issues = xia2.Test.regression.check_result(
         "X4_wide.space_group.%s" % pipeline,
         result,
         tmpdir,
         ccp4,
-        expected_space_group=expected_space_group,
+        expected_space_group=space_group,
     )
     assert success, issues

--- a/Test/regression/test_X4_wide.py
+++ b/Test/regression/test_X4_wide.py
@@ -51,8 +51,7 @@ def test_incompatible_pipeline_scaler(pipeline, scaler, tmpdir, ccp4):
     ) in result.stdout.decode("latin-1")
 
 
-@pytest.mark.parametrize("space_group", [None, "P41212", "P422"])
-def test_dials_aimless(space_group, regression_test, dials_data, tmpdir, ccp4):
+def test_dials_aimless(regression_test, dials_data, tmpdir, ccp4):
     command_line = [
         "xia2",
         "pipeline=dials-aimless",
@@ -62,18 +61,9 @@ def test_dials_aimless(space_group, regression_test, dials_data, tmpdir, ccp4):
         "truncate=cctbx",
         dials_data("x4wide").strpath,
     ]
-    if space_group:
-        command_line.append("space_group='%s'" % space_group)
-        expected_space_group = space_group
-    else:
-        expected_space_group = "P41212"
     result = procrunner.run(command_line, working_directory=tmpdir)
     success, issues = xia2.Test.regression.check_result(
-        "X4_wide.dials-aimless",
-        result,
-        tmpdir,
-        ccp4,
-        expected_space_group=expected_space_group,
+        "X4_wide.dials-aimless", result, tmpdir, ccp4, expected_space_group="P41212",
     )
     assert success, issues
 
@@ -97,8 +87,7 @@ def test_dials_aimless_with_dials_pipeline(regression_test, dials_data, tmpdir, 
     assert success, issues
 
 
-@pytest.mark.parametrize("space_group", [None, "P41212", "P422"])
-def test_dials(space_group, regression_test, dials_data, tmpdir, ccp4):
+def test_dials(regression_test, dials_data, tmpdir, ccp4):
     command_line = [
         "xia2",
         "pipeline=dials",
@@ -109,11 +98,6 @@ def test_dials(space_group, regression_test, dials_data, tmpdir, ccp4):
         "free_total=1000",
         dials_data("x4wide").strpath,
     ]
-    if space_group:
-        command_line.append("space_group='%s'" % space_group)
-        expected_space_group = space_group
-    else:
-        expected_space_group = "P41212"
     result = procrunner.run(command_line, working_directory=tmpdir)
     print(result)
     success, issues = xia2.Test.regression.check_result(
@@ -125,7 +109,7 @@ def test_dials(space_group, regression_test, dials_data, tmpdir, ccp4):
             "AUTOMATIC_DEFAULT_scaled.mtz",
             "AUTOMATIC_DEFAULT_scaled_unmerged.mtz",
         ],
-        expected_space_group=expected_space_group,
+        expected_space_group="P41212",
     )
     assert success, issues
 
@@ -174,8 +158,7 @@ def test_dials_split(multi_sweep_indexing, regression_test, dials_data, tmpdir, 
     assert success, issues
 
 
-@pytest.mark.parametrize("space_group", [None, "P41212", "P422"])
-def test_xds(space_group, regression_test, dials_data, tmpdir, ccp4, xds):
+def test_xds(regression_test, dials_data, tmpdir, ccp4, xds):
     command_line = [
         "xia2",
         "pipeline=3di",
@@ -184,19 +167,9 @@ def test_xds(space_group, regression_test, dials_data, tmpdir, ccp4, xds):
         "read_all_image_headers=False",
         dials_data("x4wide").strpath,
     ]
-    if space_group:
-        command_line.append("space_group='%s'" % space_group)
-        expected_space_group = space_group
-    else:
-        expected_space_group = "P41212"
     result = procrunner.run(command_line, working_directory=tmpdir)
     success, issues = xia2.Test.regression.check_result(
-        "X4_wide.xds",
-        result,
-        tmpdir,
-        ccp4,
-        xds,
-        expected_space_group=expected_space_group,
+        "X4_wide.xds", result, tmpdir, ccp4, xds, expected_space_group="P41212",
     )
     assert success, issues
 
@@ -249,5 +222,38 @@ def test_xds_ccp4a_split(regression_test, dials_data, tmpdir, ccp4, xds):
     result = procrunner.run(command_line, working_directory=tmpdir)
     success, issues = xia2.Test.regression.check_result(
         "X4_wide_split.ccp4a", result, tmpdir, ccp4, xds
+    )
+    assert success, issues
+
+
+@pytest.mark.parametrize(
+    "pipeline,space_group",
+    (
+        (pipeline, space_group)
+        for pipeline in ("dials", "dials-aimless", "3dii")
+        for space_group in ("P41212", "P422")
+    ),
+)
+def test_space_group(pipeline, space_group, regression_test, dials_data, tmpdir, ccp4):
+    command_line = [
+        "xia2",
+        "pipeline=%s" % pipeline,
+        "nproc=1",
+        "trust_beam_centre=True",
+        "read_all_image_headers=False",
+        "truncate=cctbx",
+        "free_total=1000",
+        "image=%s" % dials_data("x4wide").join("X4_wide_M1S4_2_0001.cbf:20:30"),
+    ]
+    command_line.append("space_group='%s'" % space_group)
+    expected_space_group = space_group
+    result = procrunner.run(command_line, working_directory=tmpdir)
+    print(result)
+    success, issues = xia2.Test.regression.check_result(
+        "X4_wide.space_group.%s" % pipeline,
+        result,
+        tmpdir,
+        ccp4,
+        expected_space_group=expected_space_group,
     )
     assert success, issues

--- a/newsfragments/420.bugfix
+++ b/newsfragments/420.bugfix
@@ -1,0 +1,2 @@
+Fix bug for space_group= option in combination with the dials pipeline where
+output mtz files would be in the Laue group, rather than the space group.


### PR DESCRIPTION
If the space group was set, xia2 would report the correct space group in the log file, but the mtz file would be in the Laue group.

Exercise space_group= option in various pipelines, check that the output data files contain the expected space group.

Fixes #419