### PR TITLE
Remove the Environment singleton

### DIFF
--- a/Applications/xia2_main.py
+++ b/Applications/xia2_main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # A top-level interface to the whole of xia2, for data processing & analysis.
 
 from __future__ import absolute_import, division, print_function
@@ -11,7 +10,7 @@ import sys
 
 from dials.util import Sorry
 from xia2.Handlers.Citations import Citations
-from xia2.Handlers.Environment import Environment, df
+from xia2.Handlers.Environment import df
 from xia2.XIA2Version import Version
 
 logger = logging.getLogger("xia2.Applications.xia2_main")
@@ -38,7 +37,7 @@ def check_environment():
 
     ccp4_keys = ["CCP4", "CCP4_SCR"]
     for k in ccp4_keys:
-        v = Environment.getenv(k)
+        v = os.getenv(k)
         if not v:
             raise RuntimeError("%s not defined - is CCP4 set up?" % k)
         if not v == v.strip():

--- a/Handlers/CIF.py
+++ b/Handlers/CIF.py
@@ -94,7 +94,7 @@ class _CIFHandler(object):
         self.collate_audit_information()
 
         path.mkdir(parents=True, exist_ok=True)
-        with path.joinpath(self._outfile).open("w") as fh:
+        with open(str(path.joinpath(self._outfile)), "w") as fh:
             self._cif.show(out=fh)
 
     def get_block(self, blockname=None):

--- a/Handlers/CIF.py
+++ b/Handlers/CIF.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
-import os.path
 
 import iotbx.cif.model
 import xia2.Handlers.Citations
@@ -89,15 +88,13 @@ class _CIFHandler(object):
         self.collate_audit_information()
         return str(self._cif)
 
-    def write_cif(self):
+    def write_cif(self, path):
         """Write CIF to file."""
         # update audit information for citations
         self.collate_audit_information()
 
-        from xia2.Handlers.Environment import Environment
-
-        data_directory = Environment.generate_directory("DataFiles")
-        with open(os.path.join(data_directory, self._outfile), "w") as fh:
+        path.mkdir(parents=True, exist_ok=True)
+        with path.joinpath(self._outfile).open("w") as fh:
             self._cif.show(out=fh)
 
     def get_block(self, blockname=None):

--- a/Handlers/Environment.py
+++ b/Handlers/Environment.py
@@ -5,13 +5,10 @@ from __future__ import absolute_import, division, print_function
 
 import atexit
 import ctypes
-import errno
 import logging
 import os
 import platform
 import tempfile
-
-import six
 
 logger = logging.getLogger("xia2.Handlers.Environment")
 
@@ -99,46 +96,6 @@ def set_up_ccp4_tmpdir():
     atexit.register(drop_ccp4_scr_tmpdir_if_possible)
 
 
-set_up_ccp4_tmpdir()
-ulimit_n()
-
-
-class _Environment(object):
-    """A class to store environmental considerations."""
-
-    def __init__(self, working_directory=None):
-        if working_directory is None:
-            self._working_directory = os.getcwd()
-        else:
-            self._working_directory = working_directory
-
-    def generate_directory(self, path_tuple):
-        """Used for generating working directories."""
-        path = self._working_directory
-
-        if isinstance(path_tuple, six.string_types):
-            path = os.path.join(path, path_tuple)
-        else:
-            path = os.path.join(path, *path_tuple)
-
-        try:
-            os.makedirs(path)
-            logger.debug("Created directory: %s", path)
-        except OSError as err:
-            if err.errno != errno.EEXIST:
-                raise
-            logger.debug("Directory exists: %s", path)
-
-        return path
-
-    def getenv(self, name):
-        """A wrapper for os.environ."""
-        return os.environ.get(name)
-
-
-Environment = _Environment()
-
-
 def get_number_cpus():
     """Portably get the number of processor cores available."""
 
@@ -155,3 +112,7 @@ def get_number_cpus():
     from libtbx.introspection import number_of_processors
 
     return number_of_processors(return_value_if_unknown=-1)
+
+
+set_up_ccp4_tmpdir()
+ulimit_n()

--- a/Handlers/Files.py
+++ b/Handlers/Files.py
@@ -11,8 +11,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import shutil
 
-from xia2.Handlers.Environment import Environment
-
 
 class _FileHandler(object):
     """A singleton class to manage files."""
@@ -38,7 +36,7 @@ class _FileHandler(object):
         self._more_data_files = {}
         self._more_data_file_keys = []
 
-    def cleanup(self):
+    def cleanup(self, base_path):
         out = open("xia2-files.txt", "w")
         for f in self._temporary_files:
             try:
@@ -51,7 +49,9 @@ class _FileHandler(object):
             out.write("Output file (%s): %s\n" % f)
 
         # copy the log files
-        log_directory = Environment.generate_directory("LogFiles")
+        log_directory = base_path.joinpath("LogFiles")
+        log_directory.mkdir(parents=True, exist_ok=True)
+        log_directory = str(log_directory)
 
         for f in self._log_file_keys:
             filename = os.path.join(log_directory, "%s.log" % f.replace(" ", "_"))
@@ -69,7 +69,9 @@ class _FileHandler(object):
             out.write("Copied html file %s to %s\n" % (self._html_files[f], filename))
 
         # copy the data files
-        data_directory = Environment.generate_directory("DataFiles")
+        data_directory = base_path.joinpath("DataFiles")
+        data_directory.mkdir(parents=True, exist_ok=True)
+        data_directory = str(data_directory)
         for f in self._data_files:
             filename = os.path.join(data_directory, os.path.split(f)[-1])
             shutil.copyfile(f, filename)
@@ -117,14 +119,15 @@ class _FileHandler(object):
         if tag not in self._more_data_file_keys:
             self._more_data_file_keys.append(key)
 
-    def get_data_file(self, filename):
+    def get_data_file(self, base_path, filename):
         """Return the point where this data file will end up!"""
 
         if filename not in self._data_files:
             return filename
 
-        data_directory = Environment.generate_directory("DataFiles")
-        return os.path.join(data_directory, os.path.split(filename)[-1])
+        data_directory = base_path.joinpath("DataFiles")
+        data_directory.mkdir(parents=True, exist_ok=True)
+        return str(data_directory.joinpath(os.path.split(filename)[-1]))
 
     def record_temporary_file(self, filename):
         # allow for file overwrites etc.
@@ -135,5 +138,5 @@ class _FileHandler(object):
 FileHandler = _FileHandler()
 
 
-def cleanup():
-    FileHandler.cleanup()
+def cleanup(base_path):
+    FileHandler.cleanup(base_path)

--- a/Interfaces/ISPyB/ISPyBXmlHandler.py
+++ b/Interfaces/ISPyB/ISPyBXmlHandler.py
@@ -246,7 +246,9 @@ class ISPyBXmlHandler(object):
                 if not isinstance(reflection_file, type("")):
                     continue
 
-                reflection_file = FileHandler.get_data_file(reflection_file)
+                reflection_file = FileHandler.get_data_file(
+                    self._project.path, reflection_file
+                )
 
                 basename = os.path.basename(reflection_file)
                 if data_directory.joinpath(basename).exists():
@@ -429,7 +431,9 @@ class ISPyBXmlHandler(object):
                 if not isinstance(reflection_file, type("")):
                     continue
 
-                reflection_file = FileHandler.get_data_file(reflection_file)
+                reflection_file = FileHandler.get_data_file(
+                    self._project.path, reflection_file
+                )
                 basename = os.path.basename(reflection_file)
 
                 if data_directory.joinpath(basename).exists():

--- a/Interfaces/ISPyB/ISPyBXmlHandler.py
+++ b/Interfaces/ISPyB/ISPyBXmlHandler.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import glob
 import os
 import time
 
@@ -19,10 +18,10 @@ def sanitize(path):
 
 
 class ISPyBXmlHandler(object):
-    def __init__(self):
+    def __init__(self, project):
         self._crystals = {}
         self._per_crystal_data = {}
-        self._project = None
+        self._project = project
 
         self._name_map = {
             "High resolution limit": "resolutionLimitHigh",
@@ -238,13 +237,10 @@ class ISPyBXmlHandler(object):
             fout.write("<processingPrograms>xia2 %s</processingPrograms>" % pipeline)
             fout.write("</AutoProcProgram>")
 
-            from xia2.Handlers.Environment import Environment
-
-            data_directory = Environment.generate_directory("DataFiles")
-            log_directory = Environment.generate_directory("LogFiles")
+            data_directory = self._project.path / "DataFiles"
+            log_directory = self._project.path / "LogFiles"
 
             for k in reflection_files:
-
                 reflection_file = reflection_files[k]
 
                 if not isinstance(reflection_file, type("")):
@@ -253,9 +249,9 @@ class ISPyBXmlHandler(object):
                 reflection_file = FileHandler.get_data_file(reflection_file)
 
                 basename = os.path.basename(reflection_file)
-                if os.path.isfile(os.path.join(data_directory, basename)):
+                if data_directory.joinpath(basename).exists():
                     # Use file in DataFiles directory in preference (if it exists)
-                    reflection_file = os.path.join(data_directory, basename)
+                    reflection_file = str(data_directory.joinpath(basename))
 
                 fout.write("<AutoProcProgramAttachment><fileType>Result")
                 fout.write(
@@ -268,14 +264,14 @@ class ISPyBXmlHandler(object):
                 )
                 fout.write("</AutoProcProgramAttachment>\n")
 
-            g = glob.glob(os.path.join(log_directory, "*merging-statistics.json"))
+            g = log_directory.glob("*merging-statistics.json")
             for merging_stats_json in g:
                 fout.write("<AutoProcProgramAttachment><fileType>Graph")
                 fout.write(
                     "</fileType><fileName>%s</fileName>"
-                    % os.path.split(merging_stats_json)[-1]
+                    % os.path.split(str(merging_stats_json))[-1]
                 )
-                fout.write("<filePath>%s</filePath>" % sanitize(log_directory))
+                fout.write("<filePath>%s</filePath>" % sanitize(str(log_directory)))
                 fout.write("</AutoProcProgramAttachment>\n")
 
             # add the xia2.txt file...
@@ -425,9 +421,7 @@ class ISPyBXmlHandler(object):
             tmp["AutoProcProgramAttachment"] = []
             tmp2 = tmp["AutoProcProgramAttachment"]
 
-            from xia2.Handlers.Environment import Environment
-
-            data_directory = Environment.generate_directory("DataFiles")
+            data_directory = self._project.path / "DataFiles"
 
             for k in reflection_files:
                 reflection_file = reflection_files[k]
@@ -438,9 +432,9 @@ class ISPyBXmlHandler(object):
                 reflection_file = FileHandler.get_data_file(reflection_file)
                 basename = os.path.basename(reflection_file)
 
-                if os.path.isfile(os.path.join(data_directory, basename)):
+                if data_directory.joinpath(basename).exists():
                     # Use file in DataFiles directory in preference (if it exists)
-                    reflection_file = os.path.join(data_directory, basename)
+                    reflection_file = str(data_directory.joinpath(basename))
 
                 tmp2.append(
                     {

--- a/Interfaces/ISPyB/ISPyBXmlHandler.py
+++ b/Interfaces/ISPyB/ISPyBXmlHandler.py
@@ -18,7 +18,7 @@ def sanitize(path):
     return path.replace(double, os.sep)
 
 
-class _ISPyBXmlHandler(object):
+class ISPyBXmlHandler(object):
     def __init__(self):
         self._crystals = {}
         self._per_crystal_data = {}
@@ -459,6 +459,3 @@ class _ISPyBXmlHandler(object):
             )
 
         return result
-
-
-ISPyBXmlHandler = _ISPyBXmlHandler()

--- a/Modules/Report/__init__.py
+++ b/Modules/Report/__init__.py
@@ -284,7 +284,7 @@ class Report(object):
         return pychef_stats.to_dict()
 
     @classmethod
-    def from_unmerged_mtz(cls, unmerged_mtz, params, report_dir=None):
+    def from_unmerged_mtz(cls, unmerged_mtz, params, report_dir):
         reader = any_reflection_file(unmerged_mtz)
         assert reader.file_type() == "ccp4_mtz"
         arrays = reader.as_miller_arrays(merge_equivalents=False)
@@ -302,17 +302,6 @@ class Report(object):
         assert intensities is not None
         assert batches is not None
         mtz_object = reader.file_content()
-
-        crystal_name = (
-            [c.name() for c in mtz_object.crystals() if c.name() != "HKL_base"]
-            or ["DEFAULT"]
-        )[0]
-        report_dir = (
-            report_dir
-            or xia2.Handlers.Environment.Environment.generate_directory(
-                [crystal_name, "report"]
-            )
-        )
 
         indices = mtz_object.extract_original_index_miller_indices()
         intensities = intensities.customized_copy(

--- a/Modules/Scaler/CCP4ScalerA.py
+++ b/Modules/Scaler/CCP4ScalerA.py
@@ -35,8 +35,8 @@ logger = logging.getLogger("xia2.Modules.Scaler.CCP4ScalerA")
 class CCP4ScalerA(Scaler):
     """An implementation of the Scaler interface using CCP4 programs."""
 
-    def __init__(self):
-        super(CCP4ScalerA, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(CCP4ScalerA, self).__init__(*args, **kwargs)
 
         self._sweep_handler = None
 
@@ -1156,12 +1156,11 @@ Scaling & analysis of unmerged intensities, absorption correction using spherica
             % aimless
         )
 
+        log_directory = self._base_path / "LogFiles"
         if absmax - absmin > 0.000001:
-            from xia2.Handlers.Environment import Environment
-
-            log_directory = Environment.generate_directory("LogFiles")
-            mapfile = os.path.join(log_directory, "absorption_surface.png")
-            generate_map(absmap, mapfile)
+            log_directory.mkdir(parents=True, exist_ok=True)
+            mapfile = log_directory / "absorption_surface.png"
+            generate_map(absmap, str(mapfile))
         else:
             logger.debug(
                 "Cannot create absorption surface: map is too flat (min: %f, max: %f)",

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -1026,7 +1026,7 @@ class CommonScaler(Scaler):
                     scaled_unmerged_mtz, anomalous=False, n_bins=n_bins
                 )
                 result.as_json(file_name=str(merging_stats_json))
-                with merging_stats_file.open("w") as fh:
+                with open(str(merging_stats_file), "w") as fh:
                     result.show(out=fh)
 
                 four_column_output = selected_band and any(selected_band)

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -35,8 +35,8 @@ def clean_reindex_operator(reindex_operator):
 class CommonScaler(Scaler):
     """Unified bits which the scalers have in common over the interface."""
 
-    def __init__(self):
-        super(CommonScaler, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(CommonScaler, self).__init__(*args, **kwargs)
 
         self._sweep_handler = None
         self._scalr_twinning_score = None

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -996,26 +996,24 @@ class CommonScaler(Scaler):
         from cctbx import sgtbx
 
         sg = sgtbx.space_group_info(str(self._scalr_likely_spacegroups[0])).group()
-        from xia2.Handlers.Environment import Environment
 
-        log_directory = Environment.generate_directory("LogFiles")
-        merging_stats_file = os.path.join(
-            log_directory,
+        log_directory = self._base_path / "LogFiles"
+        log_directory.mkdir(parents=True, exist_ok=True)
+        merging_stats_file = log_directory.joinpath(
             "%s_%s%s_merging-statistics.txt"
             % (
                 self._scalr_pname,
                 self._scalr_xname,
                 "" if wave is None else "_%s" % wave,
-            ),
+            )
         )
-        merging_stats_json = os.path.join(
-            log_directory,
+        merging_stats_json = log_directory.joinpath(
             "%s_%s%s_merging-statistics.json"
             % (
                 self._scalr_pname,
                 self._scalr_xname,
                 "" if wave is None else "_%s" % wave,
-            ),
+            )
         )
 
         result, select_result, anom_result, select_anom_result = None, None, None, None
@@ -1027,8 +1025,8 @@ class CommonScaler(Scaler):
                 result = self._iotbx_merging_statistics(
                     scaled_unmerged_mtz, anomalous=False, n_bins=n_bins
                 )
-                result.as_json(file_name=merging_stats_json)
-                with open(merging_stats_file, "w") as fh:
+                result.as_json(file_name=str(merging_stats_json))
+                with merging_stats_file.open("w") as fh:
                     result.show(out=fh)
 
                 four_column_output = selected_band and any(selected_band)

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -51,8 +51,8 @@ def clean_reindex_operator(reindex_operator):
 
 
 class DialsScaler(Scaler):
-    def __init__(self):
-        super(DialsScaler, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(DialsScaler, self).__init__(*args, **kwargs)
 
         self._scalr_scaled_refl_files = {}
         self._scalr_statistics = {}

--- a/Modules/Scaler/ScalerFactory.py
+++ b/Modules/Scaler/ScalerFactory.py
@@ -16,15 +16,14 @@ from xia2.Modules.Scaler.DialsScaler import DialsScaler
 logger = logging.getLogger("xia2.Modules.Scaler.ScalerFactory")
 
 
-def Scaler():
+def Scaler(*args, **kwargs):
     """Create a Scaler implementation."""
-
     scaler = None
     preselection = get_preferences().get("scaler")
 
     if not scaler and (not preselection or preselection == "ccp4a"):
         try:
-            scaler = CCP4ScalerA()
+            scaler = CCP4ScalerA(*args, **kwargs)
             logger.debug("Using CCP4A Scaler")
         except NotAvailableError:
             if preselection == "ccp4a":
@@ -32,7 +31,7 @@ def Scaler():
 
     if not scaler and (not preselection or preselection == "xdsa"):
         try:
-            scaler = XDSScalerA()
+            scaler = XDSScalerA(*args, **kwargs)
             logger.debug("Using XDSA Scaler")
         except NotAvailableError:
             if preselection == "xdsa":
@@ -40,7 +39,7 @@ def Scaler():
 
     if not scaler and (not preselection or preselection == "dials"):
         try:
-            scaler = DialsScaler()
+            scaler = DialsScaler(*args, **kwargs)
             logger.debug("Using DIALS Scaler")
         except NotAvailableError:
             if preselection == "dials":

--- a/Modules/Scaler/XDSScalerA.py
+++ b/Modules/Scaler/XDSScalerA.py
@@ -32,8 +32,8 @@ class XDSScalerA(Scaler):
     xds and xscale, possibly with some help from a couple of CCP4
     programs like pointless."""
 
-    def __init__(self):
-        super(XDSScalerA, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(XDSScalerA, self).__init__(*args, **kwargs)
 
         self._sweep_information = {}
 

--- a/Schema/Interfaces/Scaler.py
+++ b/Schema/Interfaces/Scaler.py
@@ -146,6 +146,7 @@ import json
 import logging
 import os
 
+import pathlib2
 from xia2.Handlers.Streams import banner
 
 logger = logging.getLogger("xia2.Schema.Interfaces.Scaler")
@@ -249,6 +250,8 @@ class Scaler(object):
         obj["__id__"] = "Scaler"
         obj["__module__"] = self.__class__.__module__
         obj["__name__"] = self.__class__.__name__
+        if self._base_path:
+            obj["_base_path"] = self._base_path.__fspath__()
 
         attributes = inspect.getmembers(self, lambda m: not inspect.isroutine(m))
         for a in attributes:
@@ -281,7 +284,12 @@ class Scaler(object):
     @classmethod
     def from_dict(cls, obj):
         assert obj["__id__"] == "Scaler"
-        return_obj = cls()
+        base_path = obj.get("_base_path")
+        if base_path:
+            base_path = pathlib2.Path(base_path)
+        else:
+            base_path = None
+        return_obj = cls(base_path=base_path)
         for k, v in obj.items():
             if k == "_scalr_integraters":
                 for k_, v_ in v.items():
@@ -306,6 +314,8 @@ class Scaler(object):
                     k_ = tuple(str(s) for s in json.loads(k_))
                     d[k_] = v_
                 v = d
+            elif k == "_base_path":
+                continue
             setattr(return_obj, k, v)
         return return_obj
 

--- a/Schema/Interfaces/Scaler.py
+++ b/Schema/Interfaces/Scaler.py
@@ -155,7 +155,7 @@ class Scaler(object):
     """An interface to present scaling functionality in a similar way to the
     integrater interface."""
 
-    def __init__(self):
+    def __init__(self, base_path=None):
         # set up a framework for storing all of the input information...
         # this should really only consist of integraters...
 
@@ -232,6 +232,7 @@ class Scaler(object):
         self._scalr_anomalous = False
 
         # admin junk
+        self._base_path = base_path
         self._working_directory = os.getcwd()
         self._scalr_pname = None
         self._scalr_xname = None

--- a/Schema/XCrystal.py
+++ b/Schema/XCrystal.py
@@ -59,7 +59,6 @@ import six
 
 # Generation of Crystallographic Information Files (CIF/mmCIF)
 from xia2.Handlers.CIF import CIF, mmCIF
-from xia2.Handlers.Environment import Environment
 from xia2.Handlers.Files import FileHandler
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Streams import banner
@@ -249,8 +248,7 @@ class XCrystal(object):
     # serialization functions
 
     def to_dict(self):
-        obj = {}
-        obj["__id__"] = "XCrystal"
+        obj = {"__id__": "XCrystal"}
 
         attributes = inspect.getmembers(self, lambda m: not (inspect.isroutine(m)))
         for a in attributes:
@@ -814,7 +812,7 @@ class XCrystal(object):
             scale_dir = PhilIndex.params.xia2.settings.scale.directory
             if scale_dir is Auto:
                 scale_dir = "scale"
-            working_directory = Environment.generate_directory([self._name, scale_dir])
+            working_path = self._project.path.joinpath(self._name, scale_dir)
 
             self._scaler = Scaler()
 
@@ -827,7 +825,7 @@ class XCrystal(object):
                 self._scaler.set_scaler_anomalous(True)
 
             # set up a sensible working directory
-            self._scaler.set_working_directory(working_directory)
+            self._scaler.set_working_directory(str(working_path))
 
             # set the reference reflection file, if we have one...
             if self._reference_reflection_file:

--- a/Schema/XCrystal.py
+++ b/Schema/XCrystal.py
@@ -563,8 +563,8 @@ class XCrystal(object):
                     target = FileHandler.get_data_file(reflections)
                     result += "Scaled reflections: %s\n" % target
 
-        CIF.write_cif()
-        mmCIF.write_cif()
+        CIF.write_cif(self._project.path / "DataFiles")
+        mmCIF.write_cif(self._project.path / "DataFiles")
 
         return result
 

--- a/Schema/XCrystal.py
+++ b/Schema/XCrystal.py
@@ -815,7 +815,7 @@ class XCrystal(object):
             working_path = self._project.path.joinpath(self._name, scale_dir)
             working_path.mkdir(parents=True, exist_ok=True)
 
-            self._scaler = Scaler()
+            self._scaler = Scaler(base_path=self._project.path)
 
             # put an inverse link in place... to support RD analysis
             # involved change to Scaler interface definition

--- a/Schema/XCrystal.py
+++ b/Schema/XCrystal.py
@@ -556,11 +556,13 @@ class XCrystal(object):
 
                 if isinstance(reflections, type({})):
                     for wavelength in list(reflections.keys()):
-                        target = FileHandler.get_data_file(reflections[wavelength])
+                        target = FileHandler.get_data_file(
+                            self._project.path, reflections[wavelength]
+                        )
                         result += "Scaled reflections (%s): %s\n" % (wavelength, target)
 
                 else:
-                    target = FileHandler.get_data_file(reflections)
+                    target = FileHandler.get_data_file(self._project.path, reflections)
                     result += "Scaled reflections: %s\n" % target
 
         CIF.write_cif(self._project.path / "DataFiles")

--- a/Schema/XCrystal.py
+++ b/Schema/XCrystal.py
@@ -813,6 +813,7 @@ class XCrystal(object):
             if scale_dir is Auto:
                 scale_dir = "scale"
             working_path = self._project.path.joinpath(self._name, scale_dir)
+            working_path.mkdir(parents=True, exist_ok=True)
 
             self._scaler = Scaler()
 

--- a/Schema/XProject.py
+++ b/Schema/XProject.py
@@ -111,11 +111,14 @@ class XProject(object):
             return rv
 
         assert [filename, string].count(None) == 1
-        if filename is not None:
+        if filename:
             with open(filename, "rb") as f:
                 string = f.read()
+            base_path = os.path.dirname(filename)
+        else:
+            base_path = None
         obj = json.loads(string, object_hook=_decode_dict)
-        return cls.from_dict(obj, base_path=os.path.dirname(filename))
+        return cls.from_dict(obj, base_path=base_path)
 
     def get_output(self):
         result = "Project: %s\n" % self._name

--- a/Schema/XProject.py
+++ b/Schema/XProject.py
@@ -4,9 +4,11 @@
 from __future__ import absolute_import, division, print_function
 
 import inspect
-import logging
 import json
+import logging
+import os
 
+import pathlib2
 import six
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Syminfo import Syminfo
@@ -22,19 +24,18 @@ class XProject(object):
     """A representation of a complete project. This will contain a dictionary
     of crystals."""
 
-    def __init__(self, xinfo_file=None, name=None):
-
+    def __init__(self, xinfo_file=None, name=None, base_path=None):
+        self.path = pathlib2.Path(base_path or os.getcwd()).absolute()
         self._crystals = {}
         if xinfo_file:
-            self.setup_from_xinfo_file(xinfo_file)
+            self._setup_from_xinfo_file(xinfo_file)
         else:
             self._name = name
 
     # serialization functions
 
     def to_dict(self):
-        obj = {}
-        obj["__id__"] = "XProject"
+        obj = {"__id__": "XProject"}
 
         attributes = inspect.getmembers(self, lambda m: not inspect.isroutine(m))
         for a in attributes:
@@ -43,12 +44,14 @@ class XProject(object):
                 obj[a[0]] = crystals
             elif a[0].startswith("__"):
                 continue
+            elif hasattr(a[1], "__fspath__"):
+                obj[a[0]] = a[1].__fspath__()
             else:
                 obj[a[0]] = a[1]
         return obj
 
     @classmethod
-    def from_dict(cls, obj):
+    def from_dict(cls, obj, base_path=None):
         assert obj["__id__"] == "XProject"
         return_obj = cls()
         for k, v in obj.items():
@@ -60,6 +63,10 @@ class XProject(object):
                     v_[cname] = cryst
                 v = v_
             setattr(return_obj, k, v)
+        if hasattr(return_obj, "path"):
+            return_obj.path = pathlib2.Path(return_obj.path).absolute()
+        else:
+            return_obj.path = pathlib2.Path(base_path or os.getcwd()).absolute()
         return return_obj
 
     def as_json(self, filename=None, compact=True):
@@ -108,7 +115,7 @@ class XProject(object):
             with open(filename, "rb") as f:
                 string = f.read()
         obj = json.loads(string, object_hook=_decode_dict)
-        return cls.from_dict(obj)
+        return cls.from_dict(obj, base_path=os.path.dirname(filename))
 
     def get_output(self):
         result = "Project: %s\n" % self._name
@@ -146,7 +153,7 @@ class XProject(object):
     def get_crystals(self):
         return self._crystals
 
-    def setup_from_xinfo_file(self, xinfo_file):
+    def _setup_from_xinfo_file(self, xinfo_file):
         """Set up this object & all subobjects based on the .xinfo
         file contents."""
 

--- a/Schema/XWavelength.py
+++ b/Schema/XWavelength.py
@@ -70,7 +70,7 @@ class XWavelength(object):
                 obj[a[0]] = sweeps
             elif a[0] == "_crystal":
                 # don't serialize this since the parent xwavelength *should* contain
-                # the reference to the child xsweeo
+                # the reference to the child xsweep
                 continue
             elif a[0].startswith("__"):
                 continue

--- a/Test/Modules/Scaler/test_CCP4ScalerA.py
+++ b/Test/Modules/Scaler/test_CCP4ScalerA.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import mock
+import pathlib2
 import pytest
 import six
 
@@ -60,7 +61,7 @@ def test_ccp4_scalerA(regression_test, ccp4, dials_data, run_in_tmpdir, nproc):
     integrater.set_integrater_sweep_name("SWEEP1")
     integrater.set_integrater_project_info("CRYST1", "WAVE1", "SWEEP1")
 
-    scaler = CCP4ScalerA()
+    scaler = CCP4ScalerA(base_path=pathlib2.Path(tmpdir))
     scaler.add_scaler_integrater(integrater)
     scaler.set_scaler_xcrystal(cryst)
     scaler.set_scaler_project_info("CRYST1", "WAVE1")

--- a/Test/Modules/Scaler/test_XDSScalerA.py
+++ b/Test/Modules/Scaler/test_XDSScalerA.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import mock
+import pathlib2
 import pytest
 import six
 
@@ -60,7 +61,7 @@ def test_xds_scalerA(regression_test, ccp4, xds, dials_data, run_in_tmpdir, npro
     integrater.set_integrater_sweep_name("SWEEP1")
     integrater.set_integrater_project_info("CRYST1", "WAVE1", "SWEEP1")
 
-    scaler = XDSScalerA()
+    scaler = XDSScalerA(base_path=pathlib2.Path(tmpdir))
     scaler.add_scaler_integrater(integrater)
     scaler.set_scaler_xcrystal(cryst)
     scaler.set_scaler_project_info("CRYST1", "WAVE1")

--- a/Test/Report/test_report.py
+++ b/Test/Report/test_report.py
@@ -7,7 +7,8 @@ import pytest
 def report(dials_data, tmpdir_factory):
     data_dir = dials_data("pychef")
     mtz = data_dir.join("insulin_dials_scaled_unmerged.mtz").strpath
-    with tmpdir_factory.mktemp("test_report").as_cwd():
+    temp_path = tmpdir_factory.mktemp("test_report")
+    with temp_path.as_cwd():
         from xia2.Modules.Analysis import (
             phil_scope,
         )  # import creates /xia2-debug.txt dropping
@@ -16,7 +17,7 @@ def report(dials_data, tmpdir_factory):
         params = phil_scope.extract()
         params.batch = []
         params.dose.batch = []
-        yield Report.from_unmerged_mtz(mtz, params)
+        yield Report.from_unmerged_mtz(mtz, params, report_dir=temp_path.strpath)
 
 
 def test_multiplicity_plots(report):

--- a/Test/Schema/test_XProject.py
+++ b/Test/Schema/test_XProject.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
+import json
 import os
 import sys
 
 import mock
+import pathlib2
 
 
 def exercise_serialization(dials_data, tmp_dir):
+    base_path = pathlib2.Path(tmp_dir)
     template = dials_data("insulin").join("insulin_1_###.img").strpath
 
     from xia2.Modules.Indexer.DialsIndexer import DialsIndexer
@@ -26,7 +29,7 @@ def exercise_serialization(dials_data, tmp_dir):
     from xia2.Schema.XSweep import XSweep
     from xia2.Schema.XSample import XSample
 
-    proj = XProject()
+    proj = XProject(base_path=base_path)
     proj._name = "PROJ1"
     cryst = XCrystal("CRYST1", proj)
     wav = XWavelength("WAVE1", cryst, wavelength=0.98)
@@ -38,7 +41,6 @@ def exercise_serialization(dials_data, tmp_dir):
     sweep = wav.add_sweep(name="SWEEP1", sample=samp, directory=directory, image=image)
     samp.add_sweep(sweep)
 
-    import json
     from dxtbx.serialize.load import _decode_dict
 
     indexer = DialsIndexer()
@@ -67,7 +69,7 @@ def exercise_serialization(dials_data, tmp_dir):
     )
     sweep._integrater = integrater
 
-    scaler = CCP4ScalerA()
+    scaler = CCP4ScalerA(base_path=base_path)
     scaler.add_scaler_integrater(integrater)
     scaler.set_scaler_xcrystal(cryst)
     scaler.set_scaler_project_info(cryst.get_name(), wav.get_name())
@@ -100,17 +102,22 @@ def exercise_serialization(dials_data, tmp_dir):
     p_str = json.dumps(p_dict, ensure_ascii=True)
     p_dict = json.loads(p_str, object_hook=_decode_dict)
     xproj = XProject.from_dict(p_dict)
+    assert xproj.path == base_path
     assert list(xproj.get_crystals().values())[0].get_project() is xproj
+    assert list(xproj.get_crystals().values())[0]._scaler._base_path == base_path
 
     json_str = proj.as_json()
     xproj = XProject.from_json(string=json_str)
+    assert xproj.path == base_path
     assert list(xproj.get_crystals().values())[0].get_project() is xproj
     print(xproj.get_output())
     print("\n".join(xproj.summarise()))
     json_str = xproj.as_json()
     xproj = XProject.from_json(string=json_str)
+    assert xproj.path == base_path
     # Test that we can serialize to json and back again
     xproj = XProject.from_json(string=xproj.as_json())
+    assert xproj.path == base_path
     xcryst = list(xproj.get_crystals().values())[0]
     assert xcryst.get_project() is xproj
     intgr = xcryst._get_integraters()[0]

--- a/command_line/html.py
+++ b/command_line/html.py
@@ -92,7 +92,11 @@ def generate_xia2_html(xinfo, filename="xia2.html", params=None, args=[]):
                     batch_params.range = si.get_batch_range()
                     params.batch.append(batch_params)
 
-            report = Report.from_unmerged_mtz(unmerged_mtz, params)
+            report_path = xinfo.path.joinpath(cname, "report")
+            report_path.mkdir(parents=True, exist_ok=True)
+            report = Report.from_unmerged_mtz(
+                unmerged_mtz, params, report_dir=str(report_path)
+            )
 
             xtriage_success, xtriage_warnings, xtriage_danger = None, None, None
             if params.xtriage_analysis:

--- a/command_line/ispyb_json.py
+++ b/command_line/ispyb_json.py
@@ -22,8 +22,9 @@ def ispyb_object():
     crystals = xinfo.get_crystals()
     assert len(crystals) == 1
     crystal = next(iter(crystals.values()))
-    ISPyBXmlHandler.add_xcrystal(crystal)
-    return ISPyBXmlHandler.json_object(command_line=command_line)
+    ispyb_hdl = ISPyBXmlHandler()
+    ispyb_hdl.add_xcrystal(crystal)
+    return ispyb_hdl.json_object(command_line=command_line)
 
 
 def zocalo_object():

--- a/command_line/ispyb_json.py
+++ b/command_line/ispyb_json.py
@@ -22,7 +22,7 @@ def ispyb_object():
     crystals = xinfo.get_crystals()
     assert len(crystals) == 1
     crystal = next(iter(crystals.values()))
-    ispyb_hdl = ISPyBXmlHandler()
+    ispyb_hdl = ISPyBXmlHandler(xinfo)
     ispyb_hdl.add_xcrystal(crystal)
     return ispyb_hdl.json_object(command_line=command_line)
 

--- a/command_line/ispyb_xml.py
+++ b/command_line/ispyb_xml.py
@@ -23,7 +23,7 @@ def ispyb_xml(xml_out):
     crystals = xinfo.get_crystals()
     assert len(crystals) == 1
     crystal = next(iter(crystals.values()))
-    ispyb_hdl = ISPyBXmlHandler()
+    ispyb_hdl = ISPyBXmlHandler(xinfo)
     ispyb_hdl.add_xcrystal(crystal)
     ispyb_hdl.write_xml(xml_out, command_line, working_phil=working_phil)
 

--- a/command_line/ispyb_xml.py
+++ b/command_line/ispyb_xml.py
@@ -23,8 +23,9 @@ def ispyb_xml(xml_out):
     crystals = xinfo.get_crystals()
     assert len(crystals) == 1
     crystal = next(iter(crystals.values()))
-    ISPyBXmlHandler.add_xcrystal(crystal)
-    ISPyBXmlHandler.write_xml(xml_out, command_line, working_phil=working_phil)
+    ispyb_hdl = ISPyBXmlHandler()
+    ispyb_hdl.add_xcrystal(crystal)
+    ispyb_hdl.write_xml(xml_out, command_line, working_phil=working_phil)
 
 
 if __name__ == "__main__":

--- a/command_line/rescale.py
+++ b/command_line/rescale.py
@@ -64,7 +64,7 @@ def run():
     )
 
     # delete all of the temporary mtz files...
-    cleanup()
+    cleanup(xinfo.path)
 
     write_citations()
 

--- a/command_line/xia2_main.py
+++ b/command_line/xia2_main.py
@@ -72,6 +72,7 @@ def xia2_main(stop_after=None):
     njob = mp_params.njob
 
     xinfo = CommandLine.get_xinfo()
+    logger.info("Project directory: %s", xinfo.path)
 
     if (
         params.xia2.settings.developmental.continue_from_previous_job

--- a/command_line/xia2_main.py
+++ b/command_line/xia2_main.py
@@ -301,7 +301,7 @@ def xia2_main(stop_after=None):
     write_citations()
 
     # delete all of the temporary mtz files...
-    cleanup()
+    cleanup(xinfo.path)
 
 
 def run():

--- a/command_line/xia2_main.py
+++ b/command_line/xia2_main.py
@@ -13,6 +13,7 @@ import traceback
 
 from dials.util import Sorry
 from dials.util.version import dials_version
+from libtbx import group_args
 import xia2.Driver.timing
 import xia2.Handlers.Streams
 import xia2.XIA2Version
@@ -64,15 +65,11 @@ def xia2_main(stop_after=None):
             logger.info("| No images assigned for crystal %s |", name)
             logger.info("-----------------------------------" + "-" * len(name))
 
-    args = []
-
     from xia2.Handlers.Phil import PhilIndex
 
     params = PhilIndex.get_python_object()
     mp_params = params.xia2.settings.multiprocessing
     njob = mp_params.njob
-
-    from libtbx import group_args
 
     xinfo = CommandLine.get_xinfo()
 
@@ -146,6 +143,7 @@ def xia2_main(stop_after=None):
     if mp_params.mode == "parallel" and njob > 1:
         driver_type = mp_params.type
         command_line_args = CommandLine.get_argv()[1:]
+        jobs = []
         for crystal_id in crystals:
             for wavelength_id in crystals[crystal_id].get_wavelength_names():
                 wavelength = crystals[crystal_id].get_xwavelength(wavelength_id)
@@ -154,7 +152,7 @@ def xia2_main(stop_after=None):
                     sweep._get_indexer()
                     sweep._get_refiner()
                     sweep._get_integrater()
-                    args.append(
+                    jobs.append(
                         (
                             group_args(
                                 driver_type=driver_type,
@@ -174,7 +172,7 @@ def xia2_main(stop_after=None):
         default_driver_type = DriverFactory.get_driver_type()
 
         # run every nth job on the current computer (no need to submit to qsub)
-        for i_job, arg in enumerate(args):
+        for i_job, arg in enumerate(jobs):
             if (i_job % njob) == 0:
                 arg[0].driver_type = default_driver_type
 
@@ -186,7 +184,7 @@ def xia2_main(stop_after=None):
 
         results = easy_mp.parallel_map(
             process_one_sweep,
-            args,
+            jobs,
             processes=njob,
             method="multiprocessing",
             qsub_command=qsub_command,


### PR DESCRIPTION
Attach a path to the XProject object instead of keeping a global variable that denotes the initial working directory.
This should solve most of the occurrences where files appear in the source directory when running tests.