### PR TITLE
Add fix_distance parameter

### DIFF
--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -207,6 +207,11 @@ dials
             "Most useful when also providing a reference geometry to xia2."
     .short_caption = "Fix geometry"
     .expert_level = 1
+  fix_distance = False
+    .type = bool
+    .help = "Whether or not to refine the detector distance in dials.index and dials.refine. " \
+    .short_caption = "Fix distance"
+    .expert_level = 1
   outlier
     .short_caption = "Centroid outlier rejection"
   {

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -209,7 +209,7 @@ dials
     .expert_level = 1
   fix_distance = False
     .type = bool
-    .help = "Whether or not to refine the detector distance in dials.index and dials.refine. " \
+    .help = "Do not refine the detector distance in dials.index and dials.refine."
     .short_caption = "Fix distance"
     .expert_level = 1
   outlier

--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -142,6 +142,8 @@ class DialsIndexer(Indexer):
         if params.fix_geometry:
             refine.set_detector_fix("all")
             refine.set_beam_fix("all")
+        elif params.fix_distance:
+            refine.set_detector_fix("distance")
         auto_logfiler(refine)
         return refine
 
@@ -554,6 +556,8 @@ class DialsIndexer(Indexer):
             if PhilIndex.params.dials.fix_geometry:
                 rbs.set_detector_fix("all")
                 rbs.set_beam_fix("all")
+            elif PhilIndex.params.dials.fix_distance:
+                rbs.set_detector_fix("distance")
 
             FileHandler.record_log_file(
                 "%s LATTICE" % self.get_indexer_full_name(), rbs.get_log_file()
@@ -701,6 +705,8 @@ class DialsIndexer(Indexer):
         if PhilIndex.params.dials.fix_geometry:
             indexer.set_detector_fix("all")
             indexer.set_beam_fix("all")
+        elif PhilIndex.params.dials.fix_distance:
+            indexer.set_detector_fix("distance")
         indexer.set_close_to_spindle_cutoff(
             PhilIndex.params.dials.close_to_spindle_cutoff
         )

--- a/Modules/Refiner/DialsRefiner.py
+++ b/Modules/Refiner/DialsRefiner.py
@@ -46,6 +46,8 @@ class DialsRefiner(Refiner):
         if PhilIndex.params.dials.fix_geometry:
             refine.set_detector_fix("all")
             refine.set_beam_fix("all")
+        elif PhilIndex.params.dials.fix_distance:
+            refine.set_detector_fix("distance")
         refine.set_close_to_spindle_cutoff(
             PhilIndex.params.dials.close_to_spindle_cutoff
         )


### PR DESCRIPTION
This provides an easy way to fix the detector distance for indexing and refinement. This can be useful for low resolution cases, or electron diffraction, where detector distance refinement may be unstable. This provides more robust refinement without being as severe as the full `fix_geometry`