### PR TITLE
Add an auto option for full_matrix minimisation in Dials scaling.

### DIFF
--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -439,10 +439,11 @@ dials
       .type = choice
       .help = "Choice of whether to refine an error model to adjust the" \
               "intensity sigmas using a two-parameter model."
-    full_matrix = True
+    full_matrix = auto
       .type = bool
-      .help = "Option to turn off GN/LM refinement round used to determine " \
-              "error estimates on scale factors."
+      .help = "Option to turn on/off Levenberg-Marquardt refinement round used" \
+              "to determine error estimates on scale factors. auto will set" \
+              "full_matrix=True if 4 sweeps or less."
     outlier_rejection = *standard simple
       .type = choice
       .help = "Choice of outlier rejection routine. Standard may take a " \

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -441,8 +441,8 @@ dials
               "intensity sigmas using a two-parameter model."
     full_matrix = auto
       .type = bool
-      .help = "Option to turn on/off Levenberg-Marquardt refinement round used" \
-              "to determine error estimates on scale factors. auto will set" \
+      .help = "Option to turn on/off Levenberg-Marquardt refinement round used " \
+              "to determine error estimates on scale factors. auto will set " \
               "full_matrix=True if 4 sweeps or less."
     outlier_rejection = *standard simple
       .type = choice

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -85,8 +85,13 @@ class DialsScaler(Scaler):
         self._scaler.set_resolution(d_min=resolution.d_min, d_max=resolution.d_max)
 
         self._scaler.set_intensities(PhilIndex.params.dials.scale.intensity_choice)
-
-        self._scaler.set_full_matrix(PhilIndex.params.dials.scale.full_matrix)
+        full_matrix = PhilIndex.params.dials.scale.full_matrix
+        if full_matrix in (libtbx.Auto, "auto", None):
+            if len(self.sweep_infos) > 4:
+                full_matrix = False
+            else:
+                full_matrix = True
+        self._scaler.set_full_matrix(full_matrix)
         self._scaler.set_outlier_rejection(
             PhilIndex.params.dials.scale.outlier_rejection
         )

--- a/newsfragments/428.feature
+++ b/newsfragments/428.feature
@@ -1,1 +1,1 @@
-Full matrix minimisation is now Auto by default. This will use full matrix for 4 sweeps or fewer.
+Full matrix minimisation is now Auto by default. This will use full matrix for 4 sweeps or fewer, meaning that large data sets now process much faster.

--- a/newsfragments/428.feature
+++ b/newsfragments/428.feature
@@ -1,0 +1,1 @@
+Full matrix minimisation is now Auto by default. This will use full matrix for 4 sweeps or fewer.


### PR DESCRIPTION
This would run full matrix scaling only if 4 sweeps or fewer. Perhaps this is too low a number and 10 would be more appropriate? Or some check based on the number of reflections?