### PR TITLE
Add exclude_images option to multiplex

### DIFF
--- a/Test/regression/test_multiplex.py
+++ b/Test/regression/test_multiplex.py
@@ -22,7 +22,7 @@ def test_proteinase_k(mocker, regression_test, ccp4, dials_data, tmpdir):
     with tmpdir.as_cwd():
         from xia2.command_line.multiplex import run
 
-        run(expts + refls)
+        run(expts + refls + ["exclude_images=0:1:10"])
     # Verify that the *_vs_dose plots have been correctly plotted
     assert Report.pychef_plots.call_count == 1
     for k in (
@@ -37,7 +37,12 @@ def test_proteinase_k(mocker, regression_test, ccp4, dials_data, tmpdir):
     multiplex_expts = load.experiment_list(
         tmpdir.join("multiplex.expt").strpath, check_format=False
     )
-    for expt in multiplex_expts:
+    for i, expt in enumerate(multiplex_expts):
+        valid_image_ranges = expt.scan.get_valid_image_ranges(expt.identifier)
+        if i == 0:
+            assert valid_image_ranges == [(11, 25)]
+        else:
+            assert valid_image_ranges == [(1, 25)]
         assert expt.crystal.get_space_group().type().lookup_symbol() == "P 41 21 2"
 
 

--- a/command_line/multiplex.py
+++ b/command_line/multiplex.py
@@ -8,6 +8,7 @@ import iotbx.phil
 
 import xia2.Handlers.Streams
 from dials.array_family import flex
+from dials.util.exclude_images import exclude_image_ranges_for_scaling
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
     parse_multiple_datasets,
@@ -25,6 +26,8 @@ help_message = """
 phil_scope = iotbx.phil.parse(
     """
 include scope xia2.Modules.MultiCrystal.ScaleAndMerge.phil_scope
+
+include scope dials.util.exclude_images.phil_scope
 
 seed = 42
   .type = int(value_min=0)
@@ -96,6 +99,10 @@ def run(args):
     reflections = flatten_reflections(params.input.reflections)
     reflections = parse_multiple_datasets(reflections)
     experiments, reflections = assign_unique_identifiers(experiments, reflections)
+
+    reflections, experiments = exclude_image_ranges_for_scaling(
+        reflections, experiments, params.exclude_images
+    )
 
     reflections_all = flex.reflection_table()
     assert len(reflections) == 1 or len(reflections) == len(experiments)


### PR DESCRIPTION
Re-use exclude_images mechanism from dials.scale. Valid image range
should be respected by cosym, symmetry and scaling.

See also dials/dials#1181