### PR TITLE
Use recalculated_unit_cell in two_theta_refine

### DIFF
--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -651,6 +651,9 @@ pipeline=dials (supported for pipeline=dials-aimless).
             self._scaled_reflections,
         )
 
+        # Run twotheta refine
+        self._update_scaled_unit_cell_from_scaled_data()
+
         ### Now export and merge so that mtz files in correct space group.
 
         ### For MAD case, need to generate individual merged and unmerged mtz
@@ -834,9 +837,6 @@ pipeline=dials (supported for pipeline=dials-aimless).
                     (self._scalr_pname, self._scalr_xname, key)
                 ] = stats
 
-        # Run twotheta refine
-        self._update_scaled_unit_cell_from_scaled_data()
-
         # add CIF data
         expts = load.experiment_list(self._scaled_experiments)
         overall_absmin = 1.0
@@ -954,6 +954,12 @@ Scaling & analysis of unmerged intensities, absorption correction using spherica
             tt_refiner.set_reflection_files([self._scaled_reflections])  # needs a list
             tt_refiner.set_output_p4p(p4p_file)
             tt_refiner.run()
+
+            self._scaled_experiments = tt_refiner.get_output_experiments()
+            FileHandler.record_more_data_file(
+                "%s %s scaled" % (self._scalr_pname, self._scalr_xname),
+                self._scaled_experiments,
+            )
 
             self._scalr_cell = tt_refiner.get_unit_cell()
             logger.info(

--- a/Test/regression/test_X4_wide.py
+++ b/Test/regression/test_X4_wide.py
@@ -103,7 +103,7 @@ def test_dials(regression_test, dials_data, tmpdir, ccp4):
         dials_data("x4wide").strpath,
     ]
     result = procrunner.run(command_line, working_directory=tmpdir)
-    scaled_expt_file = tmpdir.join("DataFiles/AUTOMATIC_DEFAULT_scaled.expt")
+    scaled_expt_file = tmpdir / "DataFiles" / "AUTOMATIC_DEFAULT_scaled.expt"
     assert scaled_expt_file.check(file=1)
     scaled_expt = load.experiment_list(scaled_expt_file.strpath)
     for crystal in scaled_expt.crystals():

--- a/Test/regression/test_X4_wide.py
+++ b/Test/regression/test_X4_wide.py
@@ -110,18 +110,17 @@ def test_dials(regression_test, dials_data, tmpdir, ccp4):
         assert crystal.get_recalculated_unit_cell() is not None
         assert len(crystal.get_recalculated_cell_parameter_sd()) == 6
         assert crystal.get_recalculated_cell_volume_sd() > 0
-    for ma in iotbx.mtz.object(
-        tmpdir.join("DataFiles/AUTOMATIC_DEFAULT_free.mtz").strpath
-    ).as_miller_arrays():
-        assert ma.unit_cell().parameters() == pytest.approx(
-            scaled_expt[0].crystal.get_recalculated_unit_cell().parameters()
-        )
-    for ma in iotbx.mtz.object(
-        tmpdir.join("DataFiles/AUTOMATIC_DEFAULT_scaled_unmerged.mtz").strpath
-    ).as_miller_arrays():
-        assert ma.unit_cell().parameters() == pytest.approx(
-            scaled_expt[0].crystal.get_recalculated_unit_cell().parameters()
-        )
+    for mtz_file in (
+        "AUTOMATIC_DEFAULT_scaled.mtz",
+        "AUTOMATIC_DEFAULT_free.mtz",
+        "AUTOMATIC_DEFAULT_scaled_unmerged.mtz",
+    ):
+        for ma in iotbx.mtz.object(
+            tmpdir.join("DataFiles").join(mtz_file).strpath
+        ).as_miller_arrays():
+            assert ma.unit_cell().parameters() == pytest.approx(
+                scaled_expt[0].crystal.get_recalculated_unit_cell().parameters()
+            )
     success, issues = xia2.Test.regression.check_result(
         "X4_wide.dials",
         result,

--- a/Test/regression/test_X4_wide.py
+++ b/Test/regression/test_X4_wide.py
@@ -4,6 +4,8 @@ import itertools
 
 import procrunner
 import pytest
+from dxtbx.serialize import load
+import iotbx.mtz
 import xia2.Test.regression
 
 
@@ -101,7 +103,25 @@ def test_dials(regression_test, dials_data, tmpdir, ccp4):
         dials_data("x4wide").strpath,
     ]
     result = procrunner.run(command_line, working_directory=tmpdir)
-    print(result)
+    scaled_expt_file = tmpdir.join("DataFiles/AUTOMATIC_DEFAULT_scaled.expt")
+    assert scaled_expt_file.check(file=1)
+    scaled_expt = load.experiment_list(scaled_expt_file.strpath)
+    for crystal in scaled_expt.crystals():
+        assert crystal.get_recalculated_unit_cell() is not None
+        assert len(crystal.get_recalculated_cell_parameter_sd()) == 6
+        assert crystal.get_recalculated_cell_volume_sd() > 0
+    for ma in iotbx.mtz.object(
+        tmpdir.join("DataFiles/AUTOMATIC_DEFAULT_free.mtz").strpath
+    ).as_miller_arrays():
+        assert ma.unit_cell().parameters() == pytest.approx(
+            scaled_expt[0].crystal.get_recalculated_unit_cell().parameters()
+        )
+    for ma in iotbx.mtz.object(
+        tmpdir.join("DataFiles/AUTOMATIC_DEFAULT_scaled_unmerged.mtz").strpath
+    ).as_miller_arrays():
+        assert ma.unit_cell().parameters() == pytest.approx(
+            scaled_expt[0].crystal.get_recalculated_unit_cell().parameters()
+        )
     success, issues = xia2.Test.regression.check_result(
         "X4_wide.dials",
         result,

--- a/Wrappers/Dials/TwoThetaRefine.py
+++ b/Wrappers/Dials/TwoThetaRefine.py
@@ -74,10 +74,10 @@ def TwoThetaRefine(DriverType=None):
             return self._reindexed_reflections
 
         def get_unit_cell(self):
-            return self._crystal.get_unit_cell().parameters()
+            return self._crystal.get_recalculated_unit_cell().parameters()
 
         def get_unit_cell_esd(self):
-            return self._crystal.get_cell_parameter_sd()
+            return self._crystal.get_recalculated_cell_parameter_sd()
 
         def set_reindex_operators(self, operators):
             assert len(operators) == len(self._experiments)


### PR DESCRIPTION
Instead pass dials.two_theta_refine output experiments directly to dials.scale.
Ensure that the dials.two_theta_refine cell is used in downstream output files.

See cctbx/dxtbx#153 and dials/dials#1214