### PR TITLE
DIALS 2.2.2

### DIFF
--- a/Data/citations.xml
+++ b/Data/citations.xml
@@ -1,5 +1,28 @@
 <citations>
 
+
+<citation program="dials.scale">
+
+<acta>Beilsten-Edmands, J. et al. (2020) Acta Cryst. D76.</acta>
+<url>https://doi.org/10.1107/S2059798320003198</url>
+<bibtex>
+@article{Beilsten-Edmands:di5035,
+author = "Beilsten-Edmands, James and Winter, Graeme and Gildea, Richard and Parkhurst, James and Waterman, David and Evans, Gwyndaf",
+title = "{Scaling diffraction data in the {\it DIALS} software package: algorithms and new approaches for multi-crystal scaling}",
+journal = "Acta Crystallographica Section D",
+year = "2020",
+volume = "76",
+number = "4",
+pages = "",
+month = "Apr",
+doi = {10.1107/S2059798320003198},
+url = {https://doi.org/10.1107/S2059798320003198},
+abstract = {In processing X-ray diffraction data, the intensities obtained from integration of the diffraction images must be corrected for experimental effects in order to place all intensities on a common scale both within and between data collections. Scaling corrects for effects such as changes in sample illumination, absorption and, to some extent, global radiation damage that cause the measured intensities of symmetry-equivalent observations to differ throughout a data set. This necessarily requires a prior evaluation of the point-group symmetry of the crystal. This paper describes and evaluates the scaling algorithms implemented within the {\it DIALS} data-processing package and demonstrates the effectiveness and key features of the implementation on example macromolecular crystallographic rotation data. In particular, the scaling algorithms enable new workflows for the scaling of multi-crystal or multi-sweep data sets, providing the analysis required to support current trends towards collecting data from ever-smaller samples. In addition, the implementation of a free-set validation method is discussed, which allows the quantification of the suitability of scaling-model and algorithm choices.},
+keywords = {diffraction, crystallography, multi-crystal, data analysis, scaling},
+}
+</bibtex>
+</citation>
+
 <citation program="dials">
 <acta>Winter, G. et al. (2018) Acta Cryst. D74, 85-97.</acta>
 <url>https://doi.org/10.1107/S2059798317017235</url>

--- a/Data/citations.xml
+++ b/Data/citations.xml
@@ -1,8 +1,6 @@
 <citations>
 
-
 <citation program="dials.scale">
-
 <acta>Beilsten-Edmands, J. et al. (2020) Acta Cryst. D76.</acta>
 <url>https://doi.org/10.1107/S2059798320003198</url>
 <bibtex>
@@ -13,7 +11,7 @@ journal = "Acta Crystallographica Section D",
 year = "2020",
 volume = "76",
 number = "4",
-pages = "",
+pages = "385--399",
 month = "Apr",
 doi = {10.1107/S2059798320003198},
 url = {https://doi.org/10.1107/S2059798320003198},

--- a/Handlers/Streams.py
+++ b/Handlers/Streams.py
@@ -163,7 +163,7 @@ class _AnsiColorStreamHandler(logging.StreamHandler):
             clean_list = self.ANY[-self.encoding :] + self.ANY[: -self.encoding]
             tumblencode = getattr(itertools, "cycle")(clean_list)
             return (
-                "".join(itertools.chain(*itertools.izip(self.utf, tumblencode, text)))
+                "".join(itertools.chain(*zip(self.utf, tumblencode, text)))
                 + self.DEFAULT
             )
         colour = self._get_color(record.levelno)

--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -413,6 +413,18 @@ class DialsIndexer(Indexer):
                                     ),
                                     image=imageset.get_path(nb_start - start),
                                     frames_to_process=(nb_start + 1, nb_end),
+                                    beam=xsweep.get_beam_centre(),
+                                    reversephi=xsweep.get_reversephi(),
+                                    distance=xsweep.get_distance(),
+                                    gain=xsweep.get_gain(),
+                                    dmin=xsweep.get_resolution_high(),
+                                    dmax=xsweep.get_resolution_low(),
+                                    polarization=xsweep.get_polarization(),
+                                    user_lattice=xsweep.get_user_lattice(),
+                                    user_cell=xsweep.get_user_cell(),
+                                    epoch=xsweep._epoch,
+                                    ice=xsweep._ice,
+                                    excluded_regions=xsweep._excluded_regions,
                                 )
                                 logger.info(
                                     "Generating new sweep: %s (%s:%i:%i)",

--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -9,6 +9,7 @@ import os
 import string
 
 import libtbx
+from cctbx import crystal, sgtbx
 
 # wrappers for programs that this needs: DIALS
 
@@ -572,8 +573,6 @@ class DialsIndexer(Indexer):
             )
             rbs.run()
 
-            from cctbx import crystal, sgtbx
-
             for k in sorted(rbs.get_bravais_summary()):
                 summary = rbs.get_bravais_summary()[k]
 
@@ -591,14 +590,8 @@ class DialsIndexer(Indexer):
                 cs = crystal.symmetry(
                     unit_cell=cryst.get_unit_cell(), space_group=cryst.get_space_group()
                 )
-                cb_op_best_to_ref = cs.change_of_basis_op_to_reference_setting()
-                cs_reference = cs.change_basis(cb_op_best_to_ref)
-                lattice = str(
-                    bravais_types.bravais_lattice(group=cs_reference.space_group())
-                )
-                cb_op = cb_op_best_to_ref * sgtbx.change_of_basis_op(
-                    str(summary["cb_op"])
-                )
+                lattice = str(bravais_types.bravais_lattice(group=cs.space_group()))
+                cb_op = sgtbx.change_of_basis_op(str(summary["cb_op"]))
 
                 self._solutions[k] = {
                     "number": k,
@@ -607,7 +600,7 @@ class DialsIndexer(Indexer):
                     "rmsd": summary["rmsd"],
                     "nspots": summary["nspots"],
                     "lattice": lattice,
-                    "cell": cs_reference.unit_cell().parameters(),
+                    "cell": cs.unit_cell().parameters(),
                     "experiments_file": summary["experiments_file"],
                     "cb_op": str(cb_op),
                 }
@@ -636,27 +629,10 @@ class DialsIndexer(Indexer):
 
             self._indxr_mosaic = self._solution["mosaic"]
 
-            experiment_list = load.experiment_list(self._solution["experiments_file"])
-            self.set_indexer_experiment_list(experiment_list)
-
-            # reindex the output experiments list to the reference setting
-            # (from the best cell/conventional setting)
-            cb_op_to_ref = (
-                experiment_list.crystals()[0]
-                .get_space_group()
-                .info()
-                .change_of_basis_op_to_reference_setting()
-            )
-            reindex = self.Reindex()
-            reindex.set_experiments_filename(self._solution["experiments_file"])
-            reindex.set_cb_op(cb_op_to_ref)
-            reindex.set_space_group(
-                str(lattice_to_spacegroup_number(self._solution["lattice"]))
-            )
-            reindex.run()
-            experiments_file = reindex.get_reindexed_experiments_filename()
+            experiments_file = self._solution["experiments_file"]
             experiment_list = load.experiment_list(experiments_file)
             self.set_indexer_experiment_list(experiment_list)
+
             self.set_indexer_payload("experiments_filename", experiments_file)
 
             # reindex the output reflection list to this solution

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -10,6 +10,7 @@ from orderedset import OrderedSet
 import libtbx
 import numpy as np
 
+from xia2.Handlers.Citations import Citations
 from xia2.Handlers.Files import FileHandler
 from xia2.lib.bits import auto_logfiler
 from xia2.Handlers.Phil import PhilIndex
@@ -339,6 +340,7 @@ class DialsScaler(Scaler):
         they are correctly indexed (via dials.symmetry) and generally tidy
         things up."""
 
+        Citations.cite("dials.scale")
         # AIM discover symmetry and reindex with dials.symmetry, and set the correct
         # reflections in si.reflections, si.experiments
 

--- a/Wrappers/Dials/RefineBravaisSettings.py
+++ b/Wrappers/Dials/RefineBravaisSettings.py
@@ -61,6 +61,7 @@ def RefineBravaisSettings(DriverType=None):
             nproc = PhilIndex.params.xia2.settings.multiprocessing.nproc
             self.set_cpu_threads(nproc)
             self.add_command_line("nproc=%i" % nproc)
+            self.add_command_line("best_monoclinic_beta=False")
             # self.add_command_line('reflections_per_degree=10')
             if self._detector_fix:
                 self.add_command_line("detector.fix=%s" % self._detector_fix)

--- a/Wrappers/Dials/Symmetry.py
+++ b/Wrappers/Dials/Symmetry.py
@@ -188,6 +188,7 @@ def DialsSymmetry(DriverType=None):
             self.add_command_line(
                 "absolute_angle_tolerance=%s" % self._absolute_angle_tolerance
             )
+            self.add_command_line("best_monoclinic_beta=False")
             if not self._json:
                 self._json = os.path.join(
                     self.get_working_directory(),
@@ -226,20 +227,17 @@ def DialsSymmetry(DriverType=None):
 
             min_cell = uctbx.unit_cell(d["min_cell_symmetry"]["unit_cell"])
             best_cell = min_cell.change_basis(cb_op=cb_op_min_best)
-            # ^^ not necessarily in reference setting e.g I2/m not C2/m
 
             cs = crystal.symmetry(
                 unit_cell=best_cell,
                 space_group=patterson_group,
                 assert_is_compatible_unit_cell=False,
             )
-            cb_op_best_to_ref = cs.change_of_basis_op_to_reference_setting()
-            cs_reference = cs.as_reference_setting()
-            self._pointgroup = cs_reference.space_group().type().lookup_symbol()
+            self._pointgroup = cs.space_group().type().lookup_symbol()
 
             self._confidence = best_solution["confidence"]
             self._totalprob = best_solution["likelihood"]
-            cb_op_inp_best = cb_op_best_to_ref * cb_op_min_best * cb_op_inp_min
+            cb_op_inp_best = cb_op_min_best * cb_op_inp_min
             self._reindex_operator = cb_op_inp_best.as_xyz()
             self._reindex_matrix = cb_op_inp_best.c().r().as_double()
 
@@ -252,17 +250,16 @@ def DialsSymmetry(DriverType=None):
                     ):
                         patterson_group = patterson_group.build_derived_acentric_group()
 
-                    cb_op_min_this = sgtbx.change_of_basis_op(str(score["cb_op"]))
+                    cb_op_inp_this = sgtbx.change_of_basis_op(str(score["cb_op"]))
                     unit_cell = min_cell.change_basis(
-                        cb_op=sgtbx.change_of_basis_op(str(cb_op_min_this))
+                        cb_op=sgtbx.change_of_basis_op(str(cb_op_inp_this))
                     )
                     cs = crystal.symmetry(
                         unit_cell=unit_cell,
                         space_group=patterson_group,
                         assert_is_compatible_unit_cell=False,
                     )
-                    cs_reference = cs.as_reference_setting()
-                    patterson_group = cs_reference.space_group()
+                    patterson_group = cs.space_group()
 
                     netzc = score["z_cc_net"]
                     # record this as a possible lattice if its Z score is positive


### PR DESCRIPTION
* restore lost sweep settings when using `remove_blanks`
* choose correct unit cell when processing data in C2 space group
* cite [Beilsten-Edmands et al.](https://doi.org/10.1107/S2059798320003198) when using `dials.scale`
* fix sporadic log weirdness on Python 3