### PR TITLE
Use best_monoclinic_beta=False in RBS and dials.symmetry (#436)

### DIFF
--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -9,6 +9,7 @@ import os
 import string
 
 import libtbx
+from cctbx import crystal, sgtbx
 
 # wrappers for programs that this needs: DIALS
 
@@ -572,8 +573,6 @@ class DialsIndexer(Indexer):
             )
             rbs.run()
 
-            from cctbx import crystal, sgtbx
-
             for k in sorted(rbs.get_bravais_summary()):
                 summary = rbs.get_bravais_summary()[k]
 
@@ -591,14 +590,8 @@ class DialsIndexer(Indexer):
                 cs = crystal.symmetry(
                     unit_cell=cryst.get_unit_cell(), space_group=cryst.get_space_group()
                 )
-                cb_op_best_to_ref = cs.change_of_basis_op_to_reference_setting()
-                cs_reference = cs.change_basis(cb_op_best_to_ref)
-                lattice = str(
-                    bravais_types.bravais_lattice(group=cs_reference.space_group())
-                )
-                cb_op = cb_op_best_to_ref * sgtbx.change_of_basis_op(
-                    str(summary["cb_op"])
-                )
+                lattice = str(bravais_types.bravais_lattice(group=cs.space_group()))
+                cb_op = sgtbx.change_of_basis_op(str(summary["cb_op"]))
 
                 self._solutions[k] = {
                     "number": k,
@@ -607,7 +600,7 @@ class DialsIndexer(Indexer):
                     "rmsd": summary["rmsd"],
                     "nspots": summary["nspots"],
                     "lattice": lattice,
-                    "cell": cs_reference.unit_cell().parameters(),
+                    "cell": cs.unit_cell().parameters(),
                     "experiments_file": summary["experiments_file"],
                     "cb_op": str(cb_op),
                 }
@@ -636,27 +629,10 @@ class DialsIndexer(Indexer):
 
             self._indxr_mosaic = self._solution["mosaic"]
 
-            experiment_list = load.experiment_list(self._solution["experiments_file"])
-            self.set_indexer_experiment_list(experiment_list)
-
-            # reindex the output experiments list to the reference setting
-            # (from the best cell/conventional setting)
-            cb_op_to_ref = (
-                experiment_list.crystals()[0]
-                .get_space_group()
-                .info()
-                .change_of_basis_op_to_reference_setting()
-            )
-            reindex = self.Reindex()
-            reindex.set_experiments_filename(self._solution["experiments_file"])
-            reindex.set_cb_op(cb_op_to_ref)
-            reindex.set_space_group(
-                str(lattice_to_spacegroup_number(self._solution["lattice"]))
-            )
-            reindex.run()
-            experiments_file = reindex.get_reindexed_experiments_filename()
+            experiments_file = self._solution["experiments_file"]
             experiment_list = load.experiment_list(experiments_file)
             self.set_indexer_experiment_list(experiment_list)
+
             self.set_indexer_payload("experiments_filename", experiments_file)
 
             # reindex the output reflection list to this solution

--- a/Wrappers/Dials/RefineBravaisSettings.py
+++ b/Wrappers/Dials/RefineBravaisSettings.py
@@ -61,6 +61,7 @@ def RefineBravaisSettings(DriverType=None):
             nproc = PhilIndex.params.xia2.settings.multiprocessing.nproc
             self.set_cpu_threads(nproc)
             self.add_command_line("nproc=%i" % nproc)
+            self.add_command_line("best_monoclinic_beta=False")
             # self.add_command_line('reflections_per_degree=10')
             if self._detector_fix:
                 self.add_command_line("detector.fix=%s" % self._detector_fix)

--- a/Wrappers/Dials/Symmetry.py
+++ b/Wrappers/Dials/Symmetry.py
@@ -188,6 +188,7 @@ def DialsSymmetry(DriverType=None):
             self.add_command_line(
                 "absolute_angle_tolerance=%s" % self._absolute_angle_tolerance
             )
+            self.add_command_line("best_monoclinic_beta=False")
             if not self._json:
                 self._json = os.path.join(
                     self.get_working_directory(),
@@ -226,20 +227,17 @@ def DialsSymmetry(DriverType=None):
 
             min_cell = uctbx.unit_cell(d["min_cell_symmetry"]["unit_cell"])
             best_cell = min_cell.change_basis(cb_op=cb_op_min_best)
-            # ^^ not necessarily in reference setting e.g I2/m not C2/m
 
             cs = crystal.symmetry(
                 unit_cell=best_cell,
                 space_group=patterson_group,
                 assert_is_compatible_unit_cell=False,
             )
-            cb_op_best_to_ref = cs.change_of_basis_op_to_reference_setting()
-            cs_reference = cs.as_reference_setting()
-            self._pointgroup = cs_reference.space_group().type().lookup_symbol()
+            self._pointgroup = cs.space_group().type().lookup_symbol()
 
             self._confidence = best_solution["confidence"]
             self._totalprob = best_solution["likelihood"]
-            cb_op_inp_best = cb_op_best_to_ref * cb_op_min_best * cb_op_inp_min
+            cb_op_inp_best = cb_op_min_best * cb_op_inp_min
             self._reindex_operator = cb_op_inp_best.as_xyz()
             self._reindex_matrix = cb_op_inp_best.c().r().as_double()
 
@@ -252,17 +250,16 @@ def DialsSymmetry(DriverType=None):
                     ):
                         patterson_group = patterson_group.build_derived_acentric_group()
 
-                    cb_op_min_this = sgtbx.change_of_basis_op(str(score["cb_op"]))
+                    cb_op_inp_this = sgtbx.change_of_basis_op(str(score["cb_op"]))
                     unit_cell = min_cell.change_basis(
-                        cb_op=sgtbx.change_of_basis_op(str(cb_op_min_this))
+                        cb_op=sgtbx.change_of_basis_op(str(cb_op_inp_this))
                     )
                     cs = crystal.symmetry(
                         unit_cell=unit_cell,
                         space_group=patterson_group,
                         assert_is_compatible_unit_cell=False,
                     )
-                    cs_reference = cs.as_reference_setting()
-                    patterson_group = cs_reference.space_group()
+                    patterson_group = cs.space_group()
 
                     netzc = score["z_cc_net"]
                     # record this as a possible lattice if its Z score is positive


### PR DESCRIPTION
This avoids some of the need for jumping through hoops converting from "best" to "reference" setting after dials.refine_bravais_settings and dials.symmetry.

See also dials/dials#1226

Fixes #435