### PR TITLE
Float some 80% of all imports

### DIFF
--- a/Applications/xia2_helpers.py
+++ b/Applications/xia2_helpers.py
@@ -8,6 +8,7 @@ import uuid
 
 from xia2.lib.bits import auto_logfiler
 from xia2.Wrappers.XIA.Integrate import Integrate as XIA2Integrate
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Applications.xia2_helpers")
 
@@ -24,8 +25,6 @@ def process_one_sweep(args):
     sweep_id = args.sweep_id
     failover = args.failover
     driver_type = args.driver_type
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     default_driver_type = DriverFactory.get_driver_type()
     DriverFactory.set_driver_type(driver_type)

--- a/Applications/xia2_helpers.py
+++ b/Applications/xia2_helpers.py
@@ -6,9 +6,9 @@ import os
 import shutil
 import uuid
 
+from xia2.Driver.DriverFactory import DriverFactory
 from xia2.lib.bits import auto_logfiler
 from xia2.Wrappers.XIA.Integrate import Integrate as XIA2Integrate
-from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Applications.xia2_helpers")
 

--- a/Applications/xia2setup.py
+++ b/Applications/xia2setup.py
@@ -10,14 +10,14 @@ import os
 import sys
 import traceback
 
+import h5py
+from libtbx import easy_mp
+from xia2.Applications.xia2setup_helpers import get_sweep
 from xia2.Experts.FindImages import image2template_directory
 from xia2.Handlers.CommandLine import CommandLine
 from xia2.Handlers.Phil import PhilIndex
-from xia2.Wrappers.XDS.XDSFiles import XDSFiles
-import h5py
-from libtbx import easy_mp
 from xia2.Schema import imageset_cache
-from xia2.Applications.xia2setup_helpers import get_sweep
+from xia2.Wrappers.XDS.XDSFiles import XDSFiles
 
 logger = logging.getLogger("xia2.Applications.xia2setup")
 

--- a/Applications/xia2setup.py
+++ b/Applications/xia2setup.py
@@ -13,6 +13,11 @@ import traceback
 from xia2.Experts.FindImages import image2template_directory
 from xia2.Handlers.CommandLine import CommandLine
 from xia2.Handlers.Phil import PhilIndex
+from xia2.Wrappers.XDS.XDSFiles import XDSFiles
+import h5py
+from libtbx import easy_mp
+from xia2.Schema import imageset_cache
+from xia2.Applications.xia2setup_helpers import get_sweep
 
 logger = logging.getLogger("xia2.Applications.xia2setup")
 
@@ -76,8 +81,6 @@ def is_sequence_name(file):
 
 
 def is_image_name(filename):
-    from xia2.Wrappers.XDS.XDSFiles import XDSFiles
-
     if os.path.isfile(filename):
 
         if os.path.split(filename)[-1] in XDSFiles:
@@ -221,8 +224,6 @@ def visit(directory, files):
 
 
 def _list_hdf5_data_files(h5_file):
-    import h5py
-
     f = h5py.File(h5_file, "r")
     filenames = [
         f["/entry/data"][k].file.filename
@@ -519,9 +520,6 @@ def _write_sweeps(sweeps, out):
 
 
 def _get_sweeps(templates):
-    from libtbx import easy_mp
-    from xia2.Applications.xia2setup_helpers import get_sweep
-
     params = PhilIndex.get_python_object()
     mp_params = params.xia2.settings.multiprocessing
     nproc = mp_params.nproc
@@ -549,8 +547,6 @@ def _get_sweeps(templates):
 
     else:
         results_list = [get_sweep((template,)) for template in templates]
-
-    from xia2.Schema import imageset_cache
 
     known_sweeps = {}
     for template, sweeplist in zip(templates, results_list):

--- a/Applications/xia2setup_helpers.py
+++ b/Applications/xia2setup_helpers.py
@@ -3,13 +3,12 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 import traceback
+from xia2.Schema.Sweep import SweepFactory
 
 # this must be defined in a separate file from xia2setup.py to be
 # compatible with easy_mp.parallel_map with method="sge" when
 # xia2setup.py is run as the __main__ program.
 def get_sweep(args):
-    from xia2.Schema.Sweep import SweepFactory
-
     assert len(args) == 1
     directory, template = os.path.split(args[0])
 

--- a/Applications/xia2setup_helpers.py
+++ b/Applications/xia2setup_helpers.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 import traceback
+
 from xia2.Schema.Sweep import SweepFactory
 
 # this must be defined in a separate file from xia2setup.py to be

--- a/Driver/QSubDriver.py
+++ b/Driver/QSubDriver.py
@@ -25,13 +25,13 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import shlex
 import subprocess
 import time
 
 from xia2.Driver.DefaultDriver import DefaultDriver
 from xia2.Driver.DriverHelper import script_writer
 from xia2.Handlers.Phil import PhilIndex
-import shlex
 
 # Now depend on Phil scope from xia2...
 

--- a/Driver/QSubDriver.py
+++ b/Driver/QSubDriver.py
@@ -30,13 +30,13 @@ import time
 
 from xia2.Driver.DefaultDriver import DefaultDriver
 from xia2.Driver.DriverHelper import script_writer
+from xia2.Handlers.Phil import PhilIndex
+import shlex
 
 # Now depend on Phil scope from xia2...
 
 
 def get_qsub_command():
-    from xia2.Handlers.Phil import PhilIndex
-
     params = PhilIndex.get_python_object()
     mp_params = params.xia2.settings.multiprocessing
     if mp_params.qsub_command:
@@ -133,8 +133,6 @@ class QSubDriver(DefaultDriver):
         qsub_command = get_qsub_command()
         if not qsub_command:
             qsub_command = "qsub"
-
-        import shlex
 
         qsub_command = shlex.split(qsub_command)
         if self._cpu_threads > 1:

--- a/Handlers/Environment.py
+++ b/Handlers/Environment.py
@@ -9,6 +9,7 @@ import logging
 import os
 import platform
 import tempfile
+
 from libtbx.introspection import number_of_processors
 
 logger = logging.getLogger("xia2.Handlers.Environment")

--- a/Handlers/Environment.py
+++ b/Handlers/Environment.py
@@ -9,6 +9,7 @@ import logging
 import os
 import platform
 import tempfile
+from libtbx.introspection import number_of_processors
 
 logger = logging.getLogger("xia2.Handlers.Environment")
 
@@ -108,8 +109,6 @@ def get_number_cpus():
         return int(os.environ.get("NSLOTS"))
     except (ValueError, TypeError):
         pass
-
-    from libtbx.introspection import number_of_processors
 
     return number_of_processors(return_value_if_unknown=-1)
 

--- a/Handlers/Flags.py
+++ b/Handlers/Flags.py
@@ -6,6 +6,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+from xia2.Wrappers.XDS.XDS import xds_read_xparm
 
 
 class _Flags(object):
@@ -32,8 +33,6 @@ class _Flags(object):
 
     def set_xparm(self, xparm):
         self._xparm = xparm
-
-        from xia2.Wrappers.XDS.XDS import xds_read_xparm
 
         xparm_info = xds_read_xparm(xparm)
 

--- a/Handlers/Flags.py
+++ b/Handlers/Flags.py
@@ -6,6 +6,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+
 from xia2.Wrappers.XDS.XDS import xds_read_xparm
 
 

--- a/Handlers/Streams.py
+++ b/Handlers/Streams.py
@@ -8,7 +8,6 @@
 from __future__ import absolute_import, division, print_function
 
 import ctypes
-import ctypes.util
 import itertools
 import logging
 import os
@@ -231,8 +230,6 @@ class _WinColorStreamHandler(logging.StreamHandler):
     def __init__(self, stream=None):
         logging.StreamHandler.__init__(self, stream)
         # get file handle for the stream
-        import ctypes
-
         # for some reason find_msvcrt() sometimes doesn't find msvcrt.dll on my system?
         crtname = ctypes.util.find_msvcrt()
         if not crtname:

--- a/Handlers/Streams.py
+++ b/Handlers/Streams.py
@@ -7,14 +7,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+import ctypes
+import ctypes.util
 import itertools
 import logging
 import os
 import platform
 import sys
 from datetime import date
-import ctypes
-import ctypes.util
 
 if not hasattr(logging, "NOTICE"):
     # Create a NOTICE log level and associated command

--- a/Handlers/Streams.py
+++ b/Handlers/Streams.py
@@ -13,6 +13,8 @@ import os
 import platform
 import sys
 from datetime import date
+import ctypes
+import ctypes.util
 
 if not hasattr(logging, "NOTICE"):
     # Create a NOTICE log level and associated command
@@ -224,15 +226,12 @@ class _WinColorStreamHandler(logging.StreamHandler):
             return cls.DEFAULT
 
     def _set_color(self, code):
-        import ctypes
-
         ctypes.windll.kernel32.SetConsoleTextAttribute(self._outhdl, code)
 
     def __init__(self, stream=None):
         logging.StreamHandler.__init__(self, stream)
         # get file handle for the stream
         import ctypes
-        import ctypes.util
 
         # for some reason find_msvcrt() sometimes doesn't find msvcrt.dll on my system?
         crtname = ctypes.util.find_msvcrt()

--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -44,6 +44,10 @@ from xia2.Handlers.Streams import banner
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Files import FileHandler
 from xia2.Experts.SymmetryExpert import lattice_to_spacegroup_number
+from xia2.Handlers.Citations import Citations
+from dials.util.ascii_art import spot_counts_per_image_plot
+from cctbx.sgtbx import bravais_types
+from dxtbx.serialize import load
 
 
 logger = logging.getLogger("xia2.Modules.Indexer.DialsIndexer")
@@ -238,8 +242,6 @@ class DialsIndexer(Indexer):
 
     def _index_prepare(self):
 
-        from xia2.Handlers.Citations import Citations
-
         Citations.cite("dials")
 
         # all_images = self.get_matching_images()
@@ -344,8 +346,6 @@ class DialsIndexer(Indexer):
 
             spot_lists.append(spot_filename)
             experiments_filenames.append(spotfinder.get_output_sweep_filename())
-
-            from dials.util.ascii_art import spot_counts_per_image_plot
 
             refl = flex.reflection_table.from_file(spot_filename)
             if not len(refl):
@@ -506,9 +506,6 @@ class DialsIndexer(Indexer):
         # not strictly the P1 cell, rather the cell that was used in indexing
         self._p1_cell = indexer._p1_cell
         self.set_indexer_payload("indexed_filename", indexer.get_indexed_filename())
-
-        from cctbx.sgtbx import bravais_types
-        from dxtbx.serialize import load
 
         indexed_file = indexer.get_indexed_filename()
         indexed_experiments = indexer.get_experiments_filename()

--- a/Modules/Indexer/XDSCheckIndexerSolution.py
+++ b/Modules/Indexer/XDSCheckIndexerSolution.py
@@ -10,6 +10,8 @@ from cctbx import crystal
 import dxtbx.serialize.xds
 from scitbx import matrix
 from xia2.Experts.LatticeExpert import s2l
+from iotbx.xds import spot_xds
+from cctbx.array_family import flex
 
 logger = logging.getLogger("xia2.Modules.Indexer.XDSCheckIndexerSolution")
 
@@ -33,12 +35,8 @@ def xds_check_indexer_solution(xparm_file, spot_file):
     goniometer = models.get_goniometer()
     scan = models.get_scan()
 
-    from iotbx.xds import spot_xds
-
     spot_xds_handle = spot_xds.reader()
     spot_xds_handle.read_file(spot_file)
-
-    from cctbx.array_family import flex
 
     centroids_px = flex.vec3_double(spot_xds_handle.centroid)
 

--- a/Modules/Indexer/XDSCheckIndexerSolution.py
+++ b/Modules/Indexer/XDSCheckIndexerSolution.py
@@ -6,12 +6,12 @@ from __future__ import absolute_import, division, print_function
 import logging
 import math
 
-from cctbx import crystal
 import dxtbx.serialize.xds
+from cctbx import crystal
+from cctbx.array_family import flex
+from iotbx.xds import spot_xds
 from scitbx import matrix
 from xia2.Experts.LatticeExpert import s2l
-from iotbx.xds import spot_xds
-from cctbx.array_family import flex
 
 logger = logging.getLogger("xia2.Modules.Indexer.XDSCheckIndexerSolution")
 

--- a/Modules/Indexer/XDSIndexer.py
+++ b/Modules/Indexer/XDSIndexer.py
@@ -33,6 +33,13 @@ from xia2.lib.bits import auto_logfiler
 from xia2.Handlers.Flags import Flags
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Files import FileHandler
+from xia2.Wrappers.Dials.Spotfinder import Spotfinder
+from xia2.Wrappers.Dials.ExportSpotXDS import ExportSpotXDS
+from dxtbx.serialize.xds import to_xds
+import dxtbx
+from dxtbx.model import Experiment, ExperimentList
+from iotbx.xds import spot_xds
+from dxtbx.serialize.xds import to_crystal
 
 logger = logging.getLogger("xia2.Modules.Indexer.XDSIndexer")
 
@@ -105,8 +112,6 @@ class XDSIndexer(IndexerSingleSweep):
         return colspot
 
     def DialsSpotfinder(self):
-        from xia2.Wrappers.Dials.Spotfinder import Spotfinder
-
         spotfinder = Spotfinder(params=PhilIndex.params.dials.find_spots)
         spotfinder.set_working_directory(self.get_working_directory())
         spotfinder.setup_from_imageset(self.get_imageset())
@@ -116,8 +121,6 @@ class XDSIndexer(IndexerSingleSweep):
         return spotfinder
 
     def DialsExportSpotXDS(self):
-        from xia2.Wrappers.Dials.ExportSpotXDS import ExportSpotXDS
-
         export = ExportSpotXDS()
         export.set_working_directory(self.get_working_directory())
         return export
@@ -303,7 +306,6 @@ class XDSIndexer(IndexerSingleSweep):
 
         xycorr.set_data_range(first, last)
         xycorr.set_background_range(self._indxr_images[0][0], self._indxr_images[0][1])
-        from dxtbx.serialize.xds import to_xds
 
         converter = to_xds(self.get_imageset())
         xds_beam_centre = converter.detector_origin
@@ -541,8 +543,6 @@ class XDSIndexer(IndexerSingleSweep):
         else:
             original_cell = None
 
-        from dxtbx.serialize.xds import to_xds
-
         converter = to_xds(self.get_imageset())
         xds_beam_centre = converter.detector_origin
 
@@ -620,14 +620,9 @@ class XDSIndexer(IndexerSingleSweep):
             self._indxr_mosaic,
         ) = idxref.get_indexing_solution()
 
-        import dxtbx
-        from dxtbx.serialize.xds import to_crystal
-
         xparm_file = os.path.join(self.get_working_directory(), "XPARM.XDS")
         models = dxtbx.load(xparm_file)
         crystal_model = to_crystal(xparm_file)
-
-        from dxtbx.model import Experiment, ExperimentList
 
         # this information gets lost when re-creating the models from the
         # XDS results - however is not refined so can simply copy from the
@@ -707,8 +702,6 @@ class XDSIndexer(IndexerSingleSweep):
 
         experiment = self.get_indexer_experiment_list()[0]
         crystal_model = experiment.crystal
-
-        from iotbx.xds import spot_xds
 
         spot_xds_handle = spot_xds.reader()
         spot_xds_handle.read_file(spot_file)

--- a/Modules/Indexer/XDSIndexerII.py
+++ b/Modules/Indexer/XDSIndexerII.py
@@ -19,6 +19,11 @@ from xia2.Handlers.Streams import banner
 from xia2.lib.bits import auto_logfiler
 from xia2.Modules.Indexer.XDSIndexer import XDSIndexer
 from xia2.Wrappers.XDS.XDS import XDSException
+import dxtbx
+from dxtbx.model import Experiment, ExperimentList
+from dxtbx.serialize.xds import to_xds
+from dxtbx.serialize.xds import to_crystal
+from xia2.Wrappers.Dials.ImportXDS import ImportXDS
 
 logger = logging.getLogger("xia2.Modules.Indexer.XDSIndexerII")
 
@@ -250,14 +255,9 @@ class XDSIndexerII(XDSIndexer):
             self._indxr_mosaic,
         ) = idxref.get_indexing_solution()
 
-        import dxtbx
-        from dxtbx.serialize.xds import to_crystal
-
         xparm_file = os.path.join(self.get_working_directory(), "XPARM.XDS")
         models = dxtbx.load(xparm_file)
         crystal_model = to_crystal(xparm_file)
-
-        from dxtbx.model import Experiment, ExperimentList
 
         # this information gets lost when re-creating the models from the
         # XDS results - however is not refined so can simply copy from the
@@ -335,8 +335,6 @@ class XDSIndexerII(XDSIndexer):
         for block in blocks[1:]:
             idxref.add_spot_range(block[0], block[1])
 
-        from dxtbx.serialize.xds import to_xds
-
         converter = to_xds(self.get_imageset())
         xds_beam_centre = converter.detector_origin
 
@@ -365,8 +363,6 @@ class XDSIndexerII(XDSIndexer):
 
             idxref.add_spot_range(block[0], block[1])
 
-        from dxtbx.serialize.xds import to_xds
-
         converter = to_xds(self.get_imageset())
         xds_beam_centre = converter.detector_origin
 
@@ -378,8 +374,6 @@ class XDSIndexerII(XDSIndexer):
 
 
 def spot_xds_to_reflection_file(spot_xds, working_directory):
-    from xia2.Wrappers.Dials.ImportXDS import ImportXDS
-
     importer = ImportXDS()
     importer.set_working_directory(working_directory)
     auto_logfiler(importer)

--- a/Modules/Indexer/XDSIndexerII.py
+++ b/Modules/Indexer/XDSIndexerII.py
@@ -11,19 +11,18 @@ import logging
 import math
 import os
 
+import dxtbx
 from dials.array_family import flex
 from dials.util.ascii_art import spot_counts_per_image_plot
+from dxtbx.model import Experiment, ExperimentList
+from dxtbx.serialize.xds import to_crystal, to_xds
 from xia2.Handlers.Files import FileHandler
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Streams import banner
 from xia2.lib.bits import auto_logfiler
 from xia2.Modules.Indexer.XDSIndexer import XDSIndexer
-from xia2.Wrappers.XDS.XDS import XDSException
-import dxtbx
-from dxtbx.model import Experiment, ExperimentList
-from dxtbx.serialize.xds import to_xds
-from dxtbx.serialize.xds import to_crystal
 from xia2.Wrappers.Dials.ImportXDS import ImportXDS
+from xia2.Wrappers.XDS.XDS import XDSException
 
 logger = logging.getLogger("xia2.Modules.Indexer.XDSIndexerII")
 

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -19,6 +19,8 @@ from xia2.Schema.Interfaces.Integrater import Integrater
 from xia2.Wrappers.Dials.ExportMtz import ExportMtz as _ExportMtz
 from xia2.Wrappers.Dials.Report import Report as _Report
 from xia2.Wrappers.Dials.anvil_correction import rescale_dac as _rescale_dac
+from xia2.Handlers.Citations import Citations
+from xia2.Wrappers.Dials.ExportXDSASCII import ExportXDSASCII
 
 logger = logging.getLogger("xia2.Modules.Integrater.DialsIntegrater")
 
@@ -163,8 +165,6 @@ class DialsIntegrater(Integrater):
         """Prepare for integration - in XDS terms this may mean rerunning
         IDXREF to get the XPARM etc. DEFPIX is considered part of the full
         integration as it is resolution dependent."""
-
-        from xia2.Handlers.Citations import Citations
 
         Citations.cite("dials")
 
@@ -660,7 +660,6 @@ class DialsIntegrater(Integrater):
 
     def get_integrater_corrected_intensities(self):
         self.integrate()
-        from xia2.Wrappers.Dials.ExportXDSASCII import ExportXDSASCII
 
         exporter = ExportXDSASCII()
         exporter.set_experiments_filename(self.get_integrated_experiments())

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -10,17 +10,16 @@ import os
 import xia2.Wrappers.Dials.Integrate
 from dials.util import Sorry
 from dxtbx.serialize import load
+from xia2.Handlers.Citations import Citations
 from xia2.Handlers.Files import FileHandler
 from xia2.Handlers.Phil import PhilIndex
 from xia2.lib.bits import auto_logfiler
 from xia2.lib.SymmetryLib import lattice_to_spacegroup
 from xia2.Schema.Interfaces.Integrater import Integrater
-
-from xia2.Wrappers.Dials.ExportMtz import ExportMtz as _ExportMtz
-from xia2.Wrappers.Dials.Report import Report as _Report
 from xia2.Wrappers.Dials.anvil_correction import rescale_dac as _rescale_dac
-from xia2.Handlers.Citations import Citations
+from xia2.Wrappers.Dials.ExportMtz import ExportMtz as _ExportMtz
 from xia2.Wrappers.Dials.ExportXDSASCII import ExportXDSASCII
+from xia2.Wrappers.Dials.Report import Report as _Report
 
 logger = logging.getLogger("xia2.Modules.Integrater.DialsIntegrater")
 

--- a/Modules/Integrater/XDSIntegrater.py
+++ b/Modules/Integrater/XDSIntegrater.py
@@ -16,13 +16,14 @@ import time
 
 import scitbx.matrix
 from dials.array_family import flex
-
+from iotbx.xds import xparm
 from xia2.Experts.SymmetryExpert import (
     lattice_to_spacegroup_number,
     mat_to_symop,
     r_to_rt,
     rt_to_r,
 )
+from xia2.Handlers.Citations import Citations
 from xia2.Handlers.Files import FileHandler
 from xia2.Handlers.Phil import PhilIndex
 from xia2.lib.bits import auto_logfiler
@@ -31,12 +32,10 @@ from xia2.Schema.Exceptions.BadLatticeError import BadLatticeError
 from xia2.Schema.Interfaces.Integrater import Integrater
 from xia2.Wrappers.CCP4.CCP4Factory import CCP4Factory
 from xia2.Wrappers.CCP4.Reindex import Reindex
+from xia2.Wrappers.Dials.ImportXDS import ImportXDS
 from xia2.Wrappers.XDS.XDSCorrect import XDSCorrect as _Correct
 from xia2.Wrappers.XDS.XDSDefpix import XDSDefpix as _Defpix
 from xia2.Wrappers.XDS.XDSIntegrate import XDSIntegrate as _Integrate
-from xia2.Wrappers.Dials.ImportXDS import ImportXDS
-from xia2.Handlers.Citations import Citations
-from iotbx.xds import xparm
 
 logger = logging.getLogger("xia2.Modules.Integrater.XDSIntegrater")
 

--- a/Modules/Integrater/XDSIntegrater.py
+++ b/Modules/Integrater/XDSIntegrater.py
@@ -35,6 +35,8 @@ from xia2.Wrappers.XDS.XDSCorrect import XDSCorrect as _Correct
 from xia2.Wrappers.XDS.XDSDefpix import XDSDefpix as _Defpix
 from xia2.Wrappers.XDS.XDSIntegrate import XDSIntegrate as _Integrate
 from xia2.Wrappers.Dials.ImportXDS import ImportXDS
+from xia2.Handlers.Citations import Citations
+from iotbx.xds import xparm
 
 logger = logging.getLogger("xia2.Modules.Integrater.XDSIntegrater")
 
@@ -191,8 +193,6 @@ class XDSIntegrater(Integrater):
         """Prepare for integration - in XDS terms this may mean rerunning
         IDXREF to get the XPARM etc. DEFPIX is considered part of the full
         integration as it is resolution dependent."""
-
-        from xia2.Handlers.Citations import Citations
 
         Citations.cite("xds")
 
@@ -716,8 +716,6 @@ class XDSIntegrater(Integrater):
         # compute misorientation of axes
 
         xparm_file = os.path.join(self.get_working_directory(), "GXPARM.XDS")
-
-        from iotbx.xds import xparm
 
         handle = xparm.reader()
         handle.read_file(xparm_file)

--- a/Modules/MtzUtils.py
+++ b/Modules/MtzUtils.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 import iotbx.mtz
+from cctbx import sgtbx
+from xia2.lib.SymmetryLib import clean_reindex_operator
 
 
 def space_group_from_mtz(file_name):
@@ -27,9 +29,6 @@ def nref_from_mtz(file_name):
 
 
 def reindex(hklin, hklout, change_of_basis_op, space_group=None):
-    from cctbx import sgtbx
-    from xia2.Modules.Scaler.CommonScaler import clean_reindex_operator
-
     if not isinstance(change_of_basis_op, sgtbx.change_of_basis_op):
         change_of_basis_op = sgtbx.change_of_basis_op(
             str(clean_reindex_operator(change_of_basis_op))

--- a/Modules/Refiner/DialsRefiner.py
+++ b/Modules/Refiner/DialsRefiner.py
@@ -13,6 +13,7 @@ from xia2.Wrappers.Dials.CombineExperiments import (
 )
 from xia2.Wrappers.Dials.Refine import Refine as _Refine
 from xia2.Wrappers.Dials.Report import Report as _Report
+from dxtbx.serialize import load
 
 
 class DialsRefiner(Refiner):
@@ -108,8 +109,6 @@ class DialsRefiner(Refiner):
             assert (
                 len(experiments.crystals()) == 1
             )  # currently only handle one lattice/sweep
-
-            from dxtbx.serialize import load
 
             scan_static = PhilIndex.params.dials.refine.scan_static
 

--- a/Modules/Refiner/DialsRefiner.py
+++ b/Modules/Refiner/DialsRefiner.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from dials.array_family import flex
-
+from dxtbx.serialize import load
 from xia2.Handlers.Files import FileHandler
 from xia2.Handlers.Phil import PhilIndex
 from xia2.lib.bits import auto_logfiler
@@ -13,7 +13,6 @@ from xia2.Wrappers.Dials.CombineExperiments import (
 )
 from xia2.Wrappers.Dials.Refine import Refine as _Refine
 from xia2.Wrappers.Dials.Report import Report as _Report
-from dxtbx.serialize import load
 
 
 class DialsRefiner(Refiner):

--- a/Modules/Refiner/XDSRefiner.py
+++ b/Modules/Refiner/XDSRefiner.py
@@ -8,6 +8,7 @@ import xia2.Wrappers.Dials.ExportXDS
 from xia2.Handlers.Phil import PhilIndex
 from xia2.lib.bits import auto_logfiler
 from xia2.Schema.Interfaces.Refiner import Refiner
+from dxtbx.model import ExperimentList
 
 logger = logging.getLogger("xia2.Modules.Refiner.XDSRefiner")
 
@@ -178,8 +179,6 @@ class XDSRefiner(Refiner):
                 # FIXME comparison needed
 
     def _refine(self):
-        from dxtbx.model import ExperimentList
-
         self._refinr_refined_experiment_list = ExperimentList()
         for epoch, idxr in self._refinr_indexers.items():
             self._refinr_payload[epoch] = copy.deepcopy(idxr._indxr_payload)

--- a/Modules/Refiner/XDSRefiner.py
+++ b/Modules/Refiner/XDSRefiner.py
@@ -5,10 +5,10 @@ import logging
 import os
 
 import xia2.Wrappers.Dials.ExportXDS
+from dxtbx.model import ExperimentList
 from xia2.Handlers.Phil import PhilIndex
 from xia2.lib.bits import auto_logfiler
 from xia2.Schema.Interfaces.Refiner import Refiner
-from dxtbx.model import ExperimentList
 
 logger = logging.getLogger("xia2.Modules.Refiner.XDSRefiner")
 

--- a/Modules/Report/__init__.py
+++ b/Modules/Report/__init__.py
@@ -6,33 +6,31 @@ import codecs
 import copy
 import os
 from collections import OrderedDict
-import six
-from six.moves import cStringIO as StringIO
 
+import dials.pychef
+import libtbx.phil
+import six
 import xia2.Handlers.Environment
 import xia2.Handlers.Files
 from cctbx.array_family import flex
-import libtbx.phil
-from iotbx import merging_statistics
-from iotbx.reflection_file_reader import any_reflection_file
-from mmtbx.scaling import printed_output
-
 from dials.pychef import dose_phil_str
 from dials.report.analysis import batch_dependent_properties
 from dials.report.plots import (
-    i_over_sig_i_vs_batch_plot,
-    scale_rmerge_vs_batch_plot,
-    ResolutionPlotsAndStats,
     IntensityStatisticsPlots,
+    ResolutionPlotsAndStats,
+    i_over_sig_i_vs_batch_plot,
+    make_image_range_table,
+    scale_rmerge_vs_batch_plot,
 )
 from dials.util.batch_handling import batch_manager
-from dials.report.plots import make_image_range_table
-
-from xia2.Modules.Analysis import batch_phil_scope, phil_scope, separate_unmerged
-from xia2.command_line.plot_multiplicity import plot_multiplicity, master_phil
-from mmtbx.scaling.xtriage import xtriage_analyses
-import dials.pychef
+from iotbx import merging_statistics
+from iotbx.reflection_file_reader import any_reflection_file
+from mmtbx.scaling import printed_output
 from mmtbx.scaling.xtriage import master_params as xtriage_master_params
+from mmtbx.scaling.xtriage import xtriage_analyses
+from six.moves import cStringIO as StringIO
+from xia2.command_line.plot_multiplicity import master_phil, plot_multiplicity
+from xia2.Modules.Analysis import batch_phil_scope, phil_scope, separate_unmerged
 
 
 class _xtriage_output(printed_output):

--- a/Modules/Report/__init__.py
+++ b/Modules/Report/__init__.py
@@ -29,6 +29,10 @@ from dials.util.batch_handling import batch_manager
 from dials.report.plots import make_image_range_table
 
 from xia2.Modules.Analysis import batch_phil_scope, phil_scope, separate_unmerged
+from xia2.command_line.plot_multiplicity import plot_multiplicity, master_phil
+from mmtbx.scaling.xtriage import xtriage_analyses
+import dials.pychef
+from mmtbx.scaling.xtriage import master_params as xtriage_master_params
 
 
 class _xtriage_output(printed_output):
@@ -106,8 +110,6 @@ class Report(object):
         self.merged_intensities = self.intensities.merge_equivalents().array()
 
     def multiplicity_plots(self, dest_path=None):
-        from xia2.command_line.plot_multiplicity import plot_multiplicity, master_phil
-
         settings = master_phil.extract()
         settings.size_inches = (5, 5)
         settings.show_missing = True
@@ -162,8 +164,6 @@ class Report(object):
         xtriage_danger = []
         s = StringIO()
         pout = printed_output(out=s)
-        from mmtbx.scaling.xtriage import xtriage_analyses
-        from mmtbx.scaling.xtriage import master_params as xtriage_master_params
 
         xtriage_params = xtriage_master_params.fetch(sources=[]).extract()
         xtriage_params.scaling.input.xray_data.skip_sanity_checks = True
@@ -262,8 +262,6 @@ class Report(object):
         return d
 
     def pychef_plots(self, n_bins=8):
-
-        import dials.pychef
 
         intensities = self.intensities
         batches = self.batches

--- a/Modules/Scaler/CCP4ScalerA.py
+++ b/Modules/Scaler/CCP4ScalerA.py
@@ -28,6 +28,11 @@ from xia2.Modules.Scaler.CCP4ScalerHelpers import (
 )
 from xia2.Modules.Scaler.CommonScaler import CommonScaler as Scaler
 from xia2.Wrappers.CCP4.CCP4Factory import CCP4Factory
+from xia2.Toolkit.AimlessSurface import (
+    evaluate_1degree,
+    scrape_coefficients,
+    generate_map,
+)
 
 logger = logging.getLogger("xia2.Modules.Scaler.CCP4ScalerA")
 
@@ -1117,12 +1122,6 @@ class CCP4ScalerA(Scaler):
             if pattern.search(line):
                 aimless = re.sub(r"\s\s+", ", ", line.strip("\t\n #"))
                 break
-
-        from xia2.Toolkit.AimlessSurface import (
-            evaluate_1degree,
-            scrape_coefficients,
-            generate_map,
-        )
 
         coefficients = scrape_coefficients(log=output)
         if coefficients:

--- a/Modules/Scaler/CCP4ScalerA.py
+++ b/Modules/Scaler/CCP4ScalerA.py
@@ -13,10 +13,7 @@ from xia2.Handlers.Citations import Citations
 from xia2.Handlers.Files import FileHandler
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Syminfo import Syminfo
-from xia2.Modules.Scaler.rebatch import rebatch
-
-from xia2.lib.bits import is_mtz_file, transpose_loggraph
-from xia2.lib.bits import nifty_power_of_ten
+from xia2.lib.bits import is_mtz_file, nifty_power_of_ten, transpose_loggraph
 from xia2.lib.SymmetryLib import sort_lattices
 from xia2.Modules import MtzUtils
 from xia2.Modules.Scaler.CCP4ScalerHelpers import (
@@ -27,12 +24,13 @@ from xia2.Modules.Scaler.CCP4ScalerHelpers import (
     get_umat_bmat_lattice_symmetry_from_mtz,
 )
 from xia2.Modules.Scaler.CommonScaler import CommonScaler as Scaler
-from xia2.Wrappers.CCP4.CCP4Factory import CCP4Factory
+from xia2.Modules.Scaler.rebatch import rebatch
 from xia2.Toolkit.AimlessSurface import (
     evaluate_1degree,
-    scrape_coefficients,
     generate_map,
+    scrape_coefficients,
 )
+from xia2.Wrappers.CCP4.CCP4Factory import CCP4Factory
 
 logger = logging.getLogger("xia2.Modules.Scaler.CCP4ScalerA")
 

--- a/Modules/Scaler/CCP4ScalerHelpers.py
+++ b/Modules/Scaler/CCP4ScalerHelpers.py
@@ -11,14 +11,14 @@ import os
 
 import xia2.Wrappers.CCP4.Pointless
 import xia2.Wrappers.Dials.Symmetry
+from cctbx.sgtbx import lattice_symmetry_group
 from iotbx import mtz
+from scitbx.matrix import sqr
 from xia2.Experts.ResolutionExperts import remove_blank
 from xia2.Handlers.Files import FileHandler
 from xia2.Handlers.Phil import PhilIndex
 from xia2.lib.bits import auto_logfiler
 from xia2.Modules import MtzUtils
-from scitbx.matrix import sqr
-from cctbx.sgtbx import lattice_symmetry_group
 
 logger = logging.getLogger("xia2.Modules.Scaler.CCP4ScalerHelpers")
 

--- a/Modules/Scaler/CCP4ScalerHelpers.py
+++ b/Modules/Scaler/CCP4ScalerHelpers.py
@@ -17,6 +17,8 @@ from xia2.Handlers.Files import FileHandler
 from xia2.Handlers.Phil import PhilIndex
 from xia2.lib.bits import auto_logfiler
 from xia2.Modules import MtzUtils
+from scitbx.matrix import sqr
+from cctbx.sgtbx import lattice_symmetry_group
 
 logger = logging.getLogger("xia2.Modules.Scaler.CCP4ScalerHelpers")
 
@@ -514,8 +516,6 @@ class SweepInformationHandler(object):
 
 
 def mosflm_B_matrix(uc):
-    from scitbx.matrix import sqr
-
     parameters = uc.parameters()
     r_parameters = uc.reciprocal_parameters()
 
@@ -544,12 +544,9 @@ def mosflm_B_matrix(uc):
 def get_umat_bmat_lattice_symmetry_from_mtz(mtz_file):
     """Get the U matrix and lattice symmetry derived from the unit cell
     constants from an MTZ file."""
-    from iotbx import mtz
-
     m = mtz.object(mtz_file)
     # assert first U matrix from batches is OK
     uc = m.crystals()[0].unit_cell()
-    from cctbx.sgtbx import lattice_symmetry_group
 
     lattice_symm = lattice_symmetry_group(uc, max_delta=0.0)
     return tuple(m.batches()[0].umat()), mosflm_B_matrix(uc), lattice_symm

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -8,15 +8,20 @@ import os
 import time
 
 import iotbx.merging_statistics
+from cctbx.xray import scatterer
+from cctbx.xray.structure import structure
 from iotbx import mtz
+from iotbx.reflection_file_reader import any_reflection_file
+from iotbx.shelx import writer
+from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
+from xia2.Handlers.CIF import CIF, mmCIF
 from xia2.Handlers.Files import FileHandler
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Streams import banner
-from xia2.Handlers.CIF import CIF, mmCIF
-from xia2.lib.bits import nifty_power_of_ten, auto_logfiler
+from xia2.lib.bits import auto_logfiler, nifty_power_of_ten
 from xia2.lib.SymmetryLib import clean_reindex_operator
-from xia2.Modules.AnalyseMyIntensities import AnalyseMyIntensities
 from xia2.Modules import MtzUtils
+from xia2.Modules.AnalyseMyIntensities import AnalyseMyIntensities
 from xia2.Modules.CCP4InterRadiationDamageDetector import (
     CCP4InterRadiationDamageDetector,
 )
@@ -26,11 +31,6 @@ from xia2.Schema.Interfaces.Scaler import Scaler
 # new resolution limit code
 from xia2.Wrappers.XIA.Merger import Merger
 from xia2.XIA2Version import Version
-from iotbx.reflection_file_reader import any_reflection_file
-from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
-from cctbx.xray import scatterer
-from iotbx.shelx import writer
-from cctbx.xray.structure import structure
 
 logger = logging.getLogger("xia2.Modules.Scaler.CommonScaler")
 

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -25,6 +25,12 @@ from xia2.Schema.Interfaces.Scaler import Scaler
 
 # new resolution limit code
 from xia2.Wrappers.XIA.Merger import Merger
+from xia2.XIA2Version import Version
+from iotbx.reflection_file_reader import any_reflection_file
+from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
+from cctbx.xray import scatterer
+from iotbx.shelx import writer
+from cctbx.xray.structure import structure
 
 logger = logging.getLogger("xia2.Modules.Scaler.CommonScaler")
 
@@ -545,7 +551,6 @@ class CommonScaler(Scaler):
 
         # finally add xia2 version to mtz history
         from iotbx.reflection_file_reader import any_reflection_file
-        from xia2.XIA2Version import Version
 
         mtz_files = [self._scalr_scaled_reflection_files["mtz"]]
         mtz_files.extend(self._scalr_scaled_reflection_files["mtz_unmerged"].values())
@@ -662,12 +667,6 @@ class CommonScaler(Scaler):
     def _scale_finish_export_shelxt(self):
         """Read hklin (unmerged reflection file) and generate SHELXT input file
         and HKL file"""
-
-        from iotbx.reflection_file_reader import any_reflection_file
-        from iotbx.shelx import writer
-        from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
-        from cctbx.xray.structure import structure
-        from cctbx.xray import scatterer
 
         for wavelength_name in self._scalr_scaled_refl_files:
             prefix = wavelength_name
@@ -892,7 +891,6 @@ class CommonScaler(Scaler):
         params = PhilIndex.params.xia2.settings.resolution
         m = Merger()
         m.set_working_directory(self.get_working_directory())
-        from xia2.lib.bits import auto_logfiler
 
         auto_logfiler(m)
         if hklin:

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -14,6 +14,7 @@ from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Streams import banner
 from xia2.Handlers.CIF import CIF, mmCIF
 from xia2.lib.bits import nifty_power_of_ten, auto_logfiler
+from xia2.lib.SymmetryLib import clean_reindex_operator
 from xia2.Modules.AnalyseMyIntensities import AnalyseMyIntensities
 from xia2.Modules import MtzUtils
 from xia2.Modules.CCP4InterRadiationDamageDetector import (
@@ -26,10 +27,6 @@ from xia2.Schema.Interfaces.Scaler import Scaler
 from xia2.Wrappers.XIA.Merger import Merger
 
 logger = logging.getLogger("xia2.Modules.Scaler.CommonScaler")
-
-
-def clean_reindex_operator(reindex_operator):
-    return reindex_operator.replace("[", "").replace("]", "")
 
 
 class CommonScaler(Scaler):

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -47,10 +47,6 @@ from iotbx.scalepack.merge import write as merge_scalepack_write
 logger = logging.getLogger("xia2.Modules.Scaler.DialsScaler")
 
 
-def clean_reindex_operator(reindex_operator):
-    return reindex_operator.replace("[", "").replace("]", "")
-
-
 class DialsScaler(Scaler):
     def __init__(self, *args, **kwargs):
         super(DialsScaler, self).__init__(*args, **kwargs)

--- a/Modules/Scaler/tools.py
+++ b/Modules/Scaler/tools.py
@@ -10,12 +10,13 @@
 #
 
 from __future__ import absolute_import, division, print_function
+from iotbx import mtz
+from cctbx.array_family import flex
+import sys
 
 
 def patch_mtz_unit_cell(mtzfile, unit_cell_parameters):
     """Overwrite unit cell stored in mtz file"""
-
-    from iotbx import mtz
 
     f = mtz.object(file_name=mtzfile)
     assert f.n_crystals() == 2, "Can only patch .mtz files with 2 crystals"
@@ -82,7 +83,6 @@ def add_dose_time_to_mtz(hklin, hklout, doses, times=None):
     # instantiate the MTZ object representation
 
     from iotbx import mtz
-    from cctbx.array_family import flex
 
     mtz_obj = mtz.object(file_name=hklin)
 
@@ -148,8 +148,6 @@ if __name__ == "__main__":
 
         doses[batch] = dose
         times[batch] = time
-
-    import sys
 
     add_dose_time_to_mtz(
         hklin=sys.argv[1], hklout=sys.argv[2], doses=doses, times=times

--- a/Modules/Scaler/tools.py
+++ b/Modules/Scaler/tools.py
@@ -10,9 +10,11 @@
 #
 
 from __future__ import absolute_import, division, print_function
-from iotbx import mtz
-from cctbx.array_family import flex
+
 import sys
+
+from cctbx.array_family import flex
+from iotbx import mtz
 
 
 def patch_mtz_unit_cell(mtzfile, unit_cell_parameters):

--- a/Schema/Interfaces/FrameProcessor.py
+++ b/Schema/Interfaces/FrameProcessor.py
@@ -17,8 +17,8 @@ import logging
 import math
 import os
 
+from dxtbx.model.detector_helpers import set_mosflm_beam_centre
 from scitbx import matrix
-
 from xia2.Experts.FindImages import (
     digest_template,
     find_matching_images,
@@ -26,9 +26,8 @@ from xia2.Experts.FindImages import (
     image2template_directory,
     template_directory_number2image,
 )
-from xia2.Wrappers.Mosflm.AutoindexHelpers import set_distance
-from dxtbx.model.detector_helpers import set_mosflm_beam_centre
 from xia2.Schema import load_imagesets
+from xia2.Wrappers.Mosflm.AutoindexHelpers import set_distance
 
 logger = logging.getLogger("xia2.Schema.Interfaces.FrameProcessor")
 

--- a/Schema/Interfaces/FrameProcessor.py
+++ b/Schema/Interfaces/FrameProcessor.py
@@ -26,6 +26,9 @@ from xia2.Experts.FindImages import (
     image2template_directory,
     template_directory_number2image,
 )
+from xia2.Wrappers.Mosflm.AutoindexHelpers import set_distance
+from dxtbx.model.detector_helpers import set_mosflm_beam_centre
+from xia2.Schema import load_imagesets
 
 logger = logging.getLogger("xia2.Schema.Interfaces.FrameProcessor")
 
@@ -139,7 +142,6 @@ class FrameProcessor(object):
     def set_distance(self, distance):
         if distance is None:
             return
-        from xia2.Wrappers.Mosflm.AutoindexHelpers import set_distance
 
         set_distance(self.get_detector(), distance)
         self._fp_distance_prov = "user"
@@ -160,8 +162,6 @@ class FrameProcessor(object):
         return self._fp_polarization
 
     def set_beam_centre(self, beam_centre):
-        from dxtbx.model.detector_helpers import set_mosflm_beam_centre
-
         try:
             set_mosflm_beam_centre(
                 self.get_detector(), self.get_beam_obj(), beam_centre
@@ -253,8 +253,6 @@ class FrameProcessor(object):
                     continue
                 images.append(j)
             self._fp_matching_images = images
-
-        from xia2.Schema import load_imagesets
 
         imagesets = load_imagesets(
             template,

--- a/Schema/Interfaces/Indexer.py
+++ b/Schema/Interfaces/Indexer.py
@@ -44,12 +44,11 @@ import logging
 import os
 from functools import reduce
 
+from cctbx.sgtbx import bravais_types
+from dxtbx.serialize.load import _decode_dict
 from xia2.Experts.LatticeExpert import SortLattices
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Streams import banner
-
-from cctbx.sgtbx import bravais_types
-from dxtbx.serialize.load import _decode_dict
 
 logger = logging.getLogger("xia2.Schema.Interfaces.Indexer")
 

--- a/Schema/Interfaces/Indexer.py
+++ b/Schema/Interfaces/Indexer.py
@@ -49,6 +49,7 @@ from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Streams import banner
 
 from cctbx.sgtbx import bravais_types
+from dxtbx.serialize.load import _decode_dict
 
 logger = logging.getLogger("xia2.Schema.Interfaces.Indexer")
 
@@ -281,8 +282,6 @@ class Indexer(object):
 
     @classmethod
     def from_json(cls, filename=None, string=None):
-        from dxtbx.serialize.load import _decode_dict
-
         assert [filename, string].count(None) == 1
         if filename is not None:
             with open(filename, "rb") as f:

--- a/Schema/Interfaces/Integrater.py
+++ b/Schema/Interfaces/Integrater.py
@@ -47,6 +47,7 @@ from xia2.Schema.Exceptions.BadLatticeError import BadLatticeError
 
 # interfaces that this inherits from ...
 from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
+from dxtbx.serialize.load import _decode_dict
 
 logger = logging.getLogger("xia2.Schema.Interfaces.Integrater")
 
@@ -204,8 +205,6 @@ class Integrater(FrameProcessor):
 
     @classmethod
     def from_json(cls, filename=None, string=None):
-        from dxtbx.serialize.load import _decode_dict
-
         assert [filename, string].count(None) == 1
         if filename is not None:
             with open(filename, "rb") as f:

--- a/Schema/Interfaces/Refiner.py
+++ b/Schema/Interfaces/Refiner.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import logging
 import os
+
 from dxtbx.serialize.load import _decode_dict
 
 logger = logging.getLogger("xia2.Schema.Interfaces.Refiner")

--- a/Schema/Interfaces/Refiner.py
+++ b/Schema/Interfaces/Refiner.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import logging
 import os
+from dxtbx.serialize.load import _decode_dict
 
 logger = logging.getLogger("xia2.Schema.Interfaces.Refiner")
 
@@ -113,8 +114,6 @@ class Refiner(object):
 
     @classmethod
     def from_json(cls, filename=None, string=None):
-        from dxtbx.serialize.load import _decode_dict
-
         assert [filename, string].count(None) == 1
         if filename is not None:
             with open(filename, "rb") as f:

--- a/Schema/Interfaces/Scaler.py
+++ b/Schema/Interfaces/Scaler.py
@@ -147,8 +147,8 @@ import logging
 import os
 
 import pathlib2
-from xia2.Handlers.Streams import banner
 from dxtbx.serialize.load import _decode_dict
+from xia2.Handlers.Streams import banner
 
 logger = logging.getLogger("xia2.Schema.Interfaces.Scaler")
 

--- a/Schema/Interfaces/Scaler.py
+++ b/Schema/Interfaces/Scaler.py
@@ -148,6 +148,7 @@ import os
 
 import pathlib2
 from xia2.Handlers.Streams import banner
+from dxtbx.serialize.load import _decode_dict
 
 logger = logging.getLogger("xia2.Schema.Interfaces.Scaler")
 
@@ -337,8 +338,6 @@ class Scaler(object):
 
     @classmethod
     def from_json(cls, filename=None, string=None):
-        from dxtbx.serialize.load import _decode_dict
-
         assert [filename, string].count(None) == 1
         if filename is not None:
             with open(filename, "r") as f:

--- a/Schema/XProject.py
+++ b/Schema/XProject.py
@@ -10,13 +10,13 @@ import os
 
 import pathlib2
 import six
+from dxtbx.serialize.load import _decode_list
 from xia2.Handlers.Phil import PhilIndex
 from xia2.Handlers.Syminfo import Syminfo
 from xia2.Handlers.XInfo import XInfo
 from xia2.Schema.XCrystal import XCrystal
 from xia2.Schema.XSample import XSample
 from xia2.Schema.XWavelength import XWavelength
-from dxtbx.serialize.load import _decode_list
 
 logger = logging.getLogger("xia2.Schema.XProject")
 

--- a/Schema/XProject.py
+++ b/Schema/XProject.py
@@ -16,6 +16,7 @@ from xia2.Handlers.XInfo import XInfo
 from xia2.Schema.XCrystal import XCrystal
 from xia2.Schema.XSample import XSample
 from xia2.Schema.XWavelength import XWavelength
+from dxtbx.serialize.load import _decode_list
 
 logger = logging.getLogger("xia2.Schema.XProject")
 
@@ -89,8 +90,6 @@ class XProject(object):
     def from_json(cls, filename=None, string=None):
         def _decode_dict(data):
             """ Decode a dict to str from unicode. """
-            from dxtbx.serialize.load import _decode_list
-
             rv = {}
             for key, value in data.items():
                 if six.PY2 and isinstance(key, six.text_type):

--- a/Schema/XSample.py
+++ b/Schema/XSample.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import inspect
+
 from xia2.Modules.DoseAccumulate import accumulate_dose
 
 

--- a/Schema/XSample.py
+++ b/Schema/XSample.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import inspect
+from xia2.Modules.DoseAccumulate import accumulate_dose
 
 
 class XSample(object):
@@ -20,8 +21,6 @@ class XSample(object):
         self.multi_indexer = None
 
     def get_epoch_to_dose(self):
-        from xia2.Modules.DoseAccumulate import accumulate_dose
-
         epoch_to_dose = accumulate_dose(
             [sweep.get_imageset() for sweep in self._sweeps]
         )

--- a/Schema/XWavelength.py
+++ b/Schema/XWavelength.py
@@ -24,11 +24,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-import logging
 import inspect
+import logging
 
-from xia2.Schema.XSweep import XSweep
 from xia2.Handlers.Phil import PhilIndex
+from xia2.Schema.XSweep import XSweep
 
 logger = logging.getLogger("xia2.Schema.XWavelength")
 

--- a/Schema/XWavelength.py
+++ b/Schema/XWavelength.py
@@ -28,6 +28,7 @@ import logging
 import inspect
 
 from xia2.Schema.XSweep import XSweep
+from xia2.Handlers.Phil import PhilIndex
 
 logger = logging.getLogger("xia2.Schema.XWavelength")
 
@@ -99,8 +100,6 @@ class XWavelength(object):
         result += "Sweeps:\n"
 
         remove = []
-
-        from xia2.Handlers.Phil import PhilIndex
 
         params = PhilIndex.get_python_object()
         failover = params.xia2.settings.failover

--- a/Test/Handlers/test_Xinfo.py
+++ b/Test/Handlers/test_Xinfo.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+from xia2.Handlers.XInfo import XInfo
+import xia2
 
 
 def test_insulin_xinfo():
-    from xia2.Handlers.XInfo import XInfo
-    import xia2
-
     xinfo_dir = os.path.join(xia2.__path__[0], "Test", "Handlers")
 
     xinfo = XInfo(os.path.join(xinfo_dir, "insulin.xinfo"))
@@ -27,9 +26,6 @@ def test_insulin_xinfo():
 
 
 def test_multi_xinfo():
-    from xia2.Handlers.XInfo import XInfo
-    import xia2
-
     xinfo_dir = os.path.join(xia2.__path__[0], "Test", "Handlers")
 
     xinfo = XInfo(os.path.join(xinfo_dir, "multi.xinfo"))
@@ -70,9 +66,6 @@ def test_multi_xinfo():
 
 
 def test_load_specific_sweeps_from_multi_xinfo():
-    from xia2.Handlers.XInfo import XInfo
-    import xia2
-
     xinfo_dir = os.path.join(xia2.__path__[0], "Test", "Handlers")
 
     xinfo = XInfo(

--- a/Test/Handlers/test_Xinfo.py
+++ b/Test/Handlers/test_Xinfo.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-from xia2.Handlers.XInfo import XInfo
+
 import xia2
+from xia2.Handlers.XInfo import XInfo
 
 
 def test_insulin_xinfo():

--- a/Test/Modules/Scaler/test_DialsScalerHelper.py
+++ b/Test/Modules/Scaler/test_DialsScalerHelper.py
@@ -9,6 +9,7 @@ from dials.array_family import flex
 from dxtbx.model.experiment_list import ExperimentList
 from dxtbx.model import Crystal, Scan, Beam, Experiment
 from dxtbx.serialize import load
+from xia2.Modules.Scaler.DialsScaler import decide_correct_lattice_using_refiner
 
 flex.set_random_seed(42)
 random.seed(42)
@@ -350,7 +351,6 @@ def test_decide_correct_lattice_using_refiner(
 ):
 
     refiner = simple_refiner(refiner_lattices)
-    from xia2.Modules.Scaler.DialsScaler import decide_correct_lattice_using_refiner
 
     result = decide_correct_lattice_using_refiner(possible_lattices, refiner)
     assert result == expected_output

--- a/Test/Modules/Scaler/test_DialsScalerHelper.py
+++ b/Test/Modules/Scaler/test_DialsScalerHelper.py
@@ -6,8 +6,8 @@ import pytest
 from cctbx import sgtbx
 from dials.algorithms.symmetry.cosym._generate_test_data import generate_intensities
 from dials.array_family import flex
+from dxtbx.model import Beam, Crystal, Experiment, Scan
 from dxtbx.model.experiment_list import ExperimentList
-from dxtbx.model import Crystal, Scan, Beam, Experiment
 from dxtbx.serialize import load
 from xia2.Modules.Scaler.DialsScaler import decide_correct_lattice_using_refiner
 

--- a/Test/System/test_run_xia2.py
+++ b/Test/System/test_run_xia2.py
@@ -1,6 +1,7 @@
 # System testing: run xia2 and check for zero exit code
 
 from __future__ import absolute_import, division, print_function
+
 import procrunner
 
 

--- a/Test/System/test_run_xia2.py
+++ b/Test/System/test_run_xia2.py
@@ -1,10 +1,9 @@
 # System testing: run xia2 and check for zero exit code
 
 from __future__ import absolute_import, division, print_function
+import procrunner
 
 
 def test_start_xia2():
-    import procrunner
-
     result = procrunner.run(["xia2"])
     assert result["exitcode"] == 0

--- a/Toolkit/E4.py
+++ b/Toolkit/E4.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import, division, print_function
+import sys
+from iotbx import reflection_file_reader
+from mmtbx.scaling.twin_analyses import twin_analyses
+from six.moves import cStringIO as StringIO
 
 
 def main():
-    import sys
-
     for argv in sys.argv[1:]:
         print(E4_mtz(argv))
 
 
 def E4_mtz(hklin, native=True):
-    from iotbx import reflection_file_reader
-
     reflection_file = reflection_file_reader.any_reflection_file(file_name=hklin)
     if reflection_file.file_type() is None:
         raise RuntimeError("error reading %s" % hklin)
@@ -29,16 +29,12 @@ def E4_mtz(hklin, native=True):
 
 
 def E4(ma):
-    import sys
-    from six.moves import cStringIO as StringIO
-
     cache_stdout = sys.stdout
     sys.stdout = StringIO()
     sg = ma.space_group()
     if sg.is_centric():
         asg = sg.build_derived_acentric_group()
         ma = ma.customized_copy(space_group_info=asg.info())
-    from mmtbx.scaling.twin_analyses import twin_analyses
 
     analysis = twin_analyses(ma)
     sys.stdout = cache_stdout

--- a/Toolkit/E4.py
+++ b/Toolkit/E4.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
+
 import sys
+
 from iotbx import reflection_file_reader
 from mmtbx.scaling.twin_analyses import twin_analyses
 from six.moves import cStringIO as StringIO

--- a/Wrappers/Cctbx/BrehmDiederichs.py
+++ b/Wrappers/Cctbx/BrehmDiederichs.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Cctbx.BrehmDiederichs")

--- a/Wrappers/Cctbx/BrehmDiederichs.py
+++ b/Wrappers/Cctbx/BrehmDiederichs.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Cctbx.BrehmDiederichs")
 
 
 def BrehmDiederichs(DriverType=None):
     """A factory for BrehmDiederichsWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/AlignCrystal.py
+++ b/Wrappers/Dials/AlignCrystal.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.AlignCrystal")
 
 
 def AlignCrystal(DriverType=None):
     """A factory for AlignCrystalWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/AlignCrystal.py
+++ b/Wrappers/Dials/AlignCrystal.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.AlignCrystal")

--- a/Wrappers/Dials/CombineExperiments.py
+++ b/Wrappers/Dials/CombineExperiments.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.CombineExperiments")
 
 
 def CombineExperiments(DriverType=None):
     """A factory for CombineExperimentsWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/CombineExperiments.py
+++ b/Wrappers/Dials/CombineExperiments.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.CombineExperiments")

--- a/Wrappers/Dials/EstimateGain.py
+++ b/Wrappers/Dials/EstimateGain.py
@@ -2,8 +2,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
 from xia2.Driver.DriverFactory import DriverFactory
+from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
 
 
 def EstimateGain(DriverType=None):

--- a/Wrappers/Dials/EstimateGain.py
+++ b/Wrappers/Dials/EstimateGain.py
@@ -3,12 +3,11 @@
 from __future__ import absolute_import, division, print_function
 
 from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
+from xia2.Driver.DriverFactory import DriverFactory
 
 
 def EstimateGain(DriverType=None):
     """A factory for EstimateGainWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/EstimateResolutionLimit.py
+++ b/Wrappers/Dials/EstimateResolutionLimit.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
+
 import logging
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.EstimateResolutionLimit")

--- a/Wrappers/Dials/EstimateResolutionLimit.py
+++ b/Wrappers/Dials/EstimateResolutionLimit.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import, division, print_function
 import logging
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.EstimateResolutionLimit")
 
 
 def EstimateResolutionLimit(DriverType=None):
     """A factory for EstimateResolutionLimitWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/ExportBest.py
+++ b/Wrappers/Dials/ExportBest.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.ExportBest")

--- a/Wrappers/Dials/ExportBest.py
+++ b/Wrappers/Dials/ExportBest.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.ExportBest")
 
 
 def ExportBest(DriverType=None):
     """A factory for ExportMtzWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/ExportMtz.py
+++ b/Wrappers/Dials/ExportMtz.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.ExportMtz")

--- a/Wrappers/Dials/ExportMtz.py
+++ b/Wrappers/Dials/ExportMtz.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.ExportMtz")
 
 
 def ExportMtz(DriverType=None):
     """A factory for ExportMtzWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/ExportXDS.py
+++ b/Wrappers/Dials/ExportXDS.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.ExportXDS")
 
 
 def ExportXDS(DriverType=None):
     """A factory for ExportXDSWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/ExportXDS.py
+++ b/Wrappers/Dials/ExportXDS.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.ExportXDS")

--- a/Wrappers/Dials/ExportXDSASCII.py
+++ b/Wrappers/Dials/ExportXDSASCII.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.ExportXDSASCII")
 
 
 def ExportXDSASCII(DriverType=None):
     """A factory for ExportXDSASCIISWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/ExportXDSASCII.py
+++ b/Wrappers/Dials/ExportXDSASCII.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.ExportXDSASCII")

--- a/Wrappers/Dials/GenerateMask.py
+++ b/Wrappers/Dials/GenerateMask.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 
+from dials.util.masking import phil_scope
 from xia2.Driver.DriverFactory import DriverFactory
 from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
-from dials.util.masking import phil_scope
 
 logger = logging.getLogger("xia2.Wrappers.Dials.GenerateMask")
 

--- a/Wrappers/Dials/GenerateMask.py
+++ b/Wrappers/Dials/GenerateMask.py
@@ -5,6 +5,7 @@ import os
 
 from xia2.Driver.DriverFactory import DriverFactory
 from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
+from dials.util.masking import phil_scope
 
 logger = logging.getLogger("xia2.Wrappers.Dials.GenerateMask")
 
@@ -40,7 +41,6 @@ def GenerateMask(DriverType=None):
             self.clear_command_line()
 
             assert self._params is not None
-            from dials.util.masking import phil_scope
 
             working_phil = phil_scope.format(self._params)
             diff_phil = phil_scope.fetch_diff(source=working_phil)

--- a/Wrappers/Dials/Import.py
+++ b/Wrappers/Dials/Import.py
@@ -4,8 +4,8 @@ import json
 import logging
 import os
 
-from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
 from xia2.Driver.DriverFactory import DriverFactory
+from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Import")
 

--- a/Wrappers/Dials/Import.py
+++ b/Wrappers/Dials/Import.py
@@ -5,14 +5,13 @@ import logging
 import os
 
 from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Import")
 
 
 def Import(DriverType=None):
     """A factory for ImportWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/Index.py
+++ b/Wrappers/Dials/Index.py
@@ -7,6 +7,8 @@ import os
 import libtbx.utils
 from xia2.Driver.DriverFactory import DriverFactory
 from xia2.Handlers.Phil import PhilIndex
+from dials.array_family import flex
+from dxtbx.serialize import load
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Index")
 
@@ -228,9 +230,6 @@ def Index(DriverType=None):
             for record in self.get_all_output():
                 if "Too few reflections to parameterise" in record:
                     logger.debug(record.strip())
-
-            from dials.array_family import flex
-            from dxtbx.serialize import load
 
             self._experiment_list = load.experiment_list(self._experiment_filename)
             self._reflections = flex.reflection_table.from_file(self._indexed_filename)

--- a/Wrappers/Dials/Index.py
+++ b/Wrappers/Dials/Index.py
@@ -5,10 +5,10 @@ import math
 import os
 
 import libtbx.utils
-from xia2.Driver.DriverFactory import DriverFactory
-from xia2.Handlers.Phil import PhilIndex
 from dials.array_family import flex
 from dxtbx.serialize import load
+from xia2.Driver.DriverFactory import DriverFactory
+from xia2.Handlers.Phil import PhilIndex
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Index")
 

--- a/Wrappers/Dials/Refine.py
+++ b/Wrappers/Dials/Refine.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Refine")

--- a/Wrappers/Dials/Refine.py
+++ b/Wrappers/Dials/Refine.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Refine")
 
 
 def Refine(DriverType=None):
     """A factory for RefineWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/RefineBravaisSettings.py
+++ b/Wrappers/Dials/RefineBravaisSettings.py
@@ -5,14 +5,13 @@ import json
 import logging
 import os
 from xia2.Handlers.Phil import PhilIndex
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.RefineBravaisSettings")
 
 
 def RefineBravaisSettings(DriverType=None):
     """A factory for RefineBravaisSettingsWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/RefineBravaisSettings.py
+++ b/Wrappers/Dials/RefineBravaisSettings.py
@@ -4,8 +4,9 @@ import copy
 import json
 import logging
 import os
-from xia2.Handlers.Phil import PhilIndex
+
 from xia2.Driver.DriverFactory import DriverFactory
+from xia2.Handlers.Phil import PhilIndex
 
 logger = logging.getLogger("xia2.Wrappers.Dials.RefineBravaisSettings")
 

--- a/Wrappers/Dials/Reindex.py
+++ b/Wrappers/Dials/Reindex.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Reindex")
 
 
 def Reindex(DriverType=None):
     """A factory for ReindexWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/Reindex.py
+++ b/Wrappers/Dials/Reindex.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import os
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Reindex")

--- a/Wrappers/Dials/Report.py
+++ b/Wrappers/Dials/Report.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Report")
 
 
 def Report(DriverType=None):
     """A factory for ReportWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/Report.py
+++ b/Wrappers/Dials/Report.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Report")

--- a/Wrappers/Dials/SearchBeamPosition.py
+++ b/Wrappers/Dials/SearchBeamPosition.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 
-from xia2.Handlers.Phil import PhilIndex
 from xia2.Driver.DriverFactory import DriverFactory
+from xia2.Handlers.Phil import PhilIndex
 
 logger = logging.getLogger("xia2.Wrappers.Dials.SearchBeamPosition")
 

--- a/Wrappers/Dials/SearchBeamPosition.py
+++ b/Wrappers/Dials/SearchBeamPosition.py
@@ -4,14 +4,13 @@ import logging
 import os
 
 from xia2.Handlers.Phil import PhilIndex
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.SearchBeamPosition")
 
 
 def SearchBeamPosition(DriverType=None):
     """A factory for SearchBeamPosition classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/ShadowPlot.py
+++ b/Wrappers/Dials/ShadowPlot.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import, division, print_function
 import json
 import os
 
-from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
 from xia2.Driver.DriverFactory import DriverFactory
+from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
 
 
 def ShadowPlot(DriverType=None):

--- a/Wrappers/Dials/ShadowPlot.py
+++ b/Wrappers/Dials/ShadowPlot.py
@@ -6,12 +6,11 @@ import json
 import os
 
 from xia2.Schema.Interfaces.FrameProcessor import FrameProcessor
+from xia2.Driver.DriverFactory import DriverFactory
 
 
 def ShadowPlot(DriverType=None):
     """A factory for ShadowPlotWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/SplitExperiments.py
+++ b/Wrappers/Dials/SplitExperiments.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.SplitExperiments")
 
 
 def SplitExperiments(DriverType=None):
     """A factory for CombineExperimentsWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/SplitExperiments.py
+++ b/Wrappers/Dials/SplitExperiments.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.SplitExperiments")

--- a/Wrappers/Dials/Spotfinder.py
+++ b/Wrappers/Dials/Spotfinder.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 
-from xia2.Handlers.Phil import PhilIndex
 from xia2.Driver.DriverFactory import DriverFactory
+from xia2.Handlers.Phil import PhilIndex
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Spotfinder")
 

--- a/Wrappers/Dials/Spotfinder.py
+++ b/Wrappers/Dials/Spotfinder.py
@@ -4,14 +4,13 @@ import logging
 import os
 
 from xia2.Handlers.Phil import PhilIndex
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.Spotfinder")
 
 
 def Spotfinder(DriverType=None):
     """A factory for SpotfinderWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/StereographicProjection.py
+++ b/Wrappers/Dials/StereographicProjection.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.StereographicProjection")
 
 
 def StereographicProjection(DriverType=None):
     """A factory for StereographicProjectionWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/Wrappers/Dials/StereographicProjection.py
+++ b/Wrappers/Dials/StereographicProjection.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.StereographicProjection")

--- a/Wrappers/Dials/TwoThetaRefine.py
+++ b/Wrappers/Dials/TwoThetaRefine.py
@@ -5,9 +5,9 @@ import os
 
 import iotbx.cif
 import iotbx.cif.model
+from dxtbx.model.experiment_list import ExperimentListFactory
 from xia2.Driver.DriverFactory import DriverFactory
 from xia2.Handlers.Citations import Citations
-from dxtbx.model.experiment_list import ExperimentListFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.TwoThetaRefine")
 

--- a/Wrappers/Dials/TwoThetaRefine.py
+++ b/Wrappers/Dials/TwoThetaRefine.py
@@ -7,6 +7,7 @@ import iotbx.cif
 import iotbx.cif.model
 from xia2.Driver.DriverFactory import DriverFactory
 from xia2.Handlers.Citations import Citations
+from dxtbx.model.experiment_list import ExperimentListFactory
 
 logger = logging.getLogger("xia2.Wrappers.Dials.TwoThetaRefine")
 
@@ -173,8 +174,6 @@ def TwoThetaRefine(DriverType=None):
                 raise RuntimeError("unit cell not refined")
 
             self.check_for_errors()
-
-            from dxtbx.model.experiment_list import ExperimentListFactory
 
             experiments = ExperimentListFactory.from_json_file(
                 self.get_output_experiments(), check_format=False

--- a/Wrappers/XIA/Report.py
+++ b/Wrappers/XIA/Report.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 import shutil
+
 from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.XIA.Report")

--- a/Wrappers/XIA/Report.py
+++ b/Wrappers/XIA/Report.py
@@ -3,14 +3,13 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 import shutil
+from xia2.Driver.DriverFactory import DriverFactory
 
 logger = logging.getLogger("xia2.Wrappers.XIA.Report")
 
 
 def Report(DriverType=None):
     """A factory for ReportWrapper classes."""
-
-    from xia2.Driver.DriverFactory import DriverFactory
 
     DriverInstance = DriverFactory.Driver(DriverType)
 

--- a/command_line/compare_merging_stats.py
+++ b/command_line/compare_merging_stats.py
@@ -8,6 +8,7 @@ import iotbx.merging_statistics
 import iotbx.phil
 from cctbx import uctbx
 from dials.util.options import OptionParser
+from cycler import cycler
 
 help_message = """
 """
@@ -141,8 +142,6 @@ def plot_merging_stats(
 
     if style is not None:
         plt.style.use(style)
-
-    from cycler import cycler
 
     colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
     plt.rcParams["axes.titlesize"] = "medium"

--- a/command_line/compare_merging_stats.py
+++ b/command_line/compare_merging_stats.py
@@ -7,8 +7,8 @@ import sys
 import iotbx.merging_statistics
 import iotbx.phil
 from cctbx import uctbx
-from dials.util.options import OptionParser
 from cycler import cycler
+from dials.util.options import OptionParser
 
 help_message = """
 """

--- a/command_line/ispyb_json.py
+++ b/command_line/ispyb_json.py
@@ -6,8 +6,8 @@ import sys
 
 import xia2.Handlers.Streams
 import xia2.Interfaces.ISPyB
-from xia2.Schema.XProject import XProject
 from xia2.Interfaces.ISPyB.ISPyBXmlHandler import ISPyBXmlHandler
+from xia2.Schema.XProject import XProject
 
 
 def ispyb_object():

--- a/command_line/ispyb_json.py
+++ b/command_line/ispyb_json.py
@@ -7,11 +7,10 @@ import sys
 import xia2.Handlers.Streams
 import xia2.Interfaces.ISPyB
 from xia2.Schema.XProject import XProject
+from xia2.Interfaces.ISPyB.ISPyBXmlHandler import ISPyBXmlHandler
 
 
 def ispyb_object():
-    from xia2.Interfaces.ISPyB.ISPyBXmlHandler import ISPyBXmlHandler
-
     assert os.path.exists("xia2.json")
     assert os.path.exists("xia2.txt")
     command_line = ""

--- a/command_line/npp.py
+++ b/command_line/npp.py
@@ -6,11 +6,10 @@ import sys
 import xia2.Handlers.Streams
 from iotbx.reflection_file_reader import any_reflection_file
 from scitbx.array_family import flex
+from xia2.Toolkit.NPP import npp_ify
 
 
 def npp(hklin):
-    from xia2.Toolkit.NPP import npp_ify
-
     reader = any_reflection_file(hklin)
     intensities = [
         ma

--- a/command_line/plot_multiplicity.py
+++ b/command_line/plot_multiplicity.py
@@ -8,10 +8,10 @@ import sys
 import iotbx.phil
 import six
 from cctbx.miller.display import render_2d, scene
-from scitbx.array_family import flex
 from dials.util import Sorry
 from iotbx.gui_tools.reflections import get_array_description
 from iotbx.reflection_file_reader import any_reflection_file
+from scitbx.array_family import flex
 
 
 class MultiplicityViewPng(render_2d):

--- a/command_line/plot_multiplicity.py
+++ b/command_line/plot_multiplicity.py
@@ -9,6 +9,9 @@ import iotbx.phil
 import six
 from cctbx.miller.display import render_2d, scene
 from scitbx.array_family import flex
+from dials.util import Sorry
+from iotbx.gui_tools.reflections import get_array_description
+from iotbx.reflection_file_reader import any_reflection_file
 
 
 class MultiplicityViewPng(render_2d):
@@ -323,10 +326,6 @@ font_size = 20
 
 
 def run(args):
-    from dials.util import Sorry
-    from iotbx.reflection_file_reader import any_reflection_file
-    from iotbx.gui_tools.reflections import get_array_description
-
     pcl = iotbx.phil.process_command_line_with_files(
         args=args,
         master_phil=master_phil,

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -8,9 +8,9 @@ import sys
 from collections import OrderedDict
 
 import iotbx.phil
-from dials.util.options import OptionParser
-from jinja2 import Environment, ChoiceLoader, PackageLoader
 import xia2.Handlers.Streams
+from dials.util.options import OptionParser
+from jinja2 import ChoiceLoader, Environment, PackageLoader
 from xia2.Modules.Report import Report
 from xia2.XIA2Version import Version
 

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -12,6 +12,7 @@ from dials.util.options import OptionParser
 from jinja2 import Environment, ChoiceLoader, PackageLoader
 import xia2.Handlers.Streams
 from xia2.Modules.Report import Report
+from xia2.XIA2Version import Version
 
 phil_scope = iotbx.phil.parse(
     """\
@@ -35,8 +36,6 @@ help_message = """
 
 
 def run(args):
-    from xia2.XIA2Version import Version
-
     usage = "xia2.report [options] scaled_unmerged.mtz"
 
     parser = OptionParser(

--- a/command_line/small_molecule.py
+++ b/command_line/small_molecule.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, division, print_function
+import sys
 
 if __name__ == "__main__":
-    import sys
-
     if "small_molecule=true" not in sys.argv and len(sys.argv) > 1:
         sys.argv.insert(1, "small_molecule=true")
     # clean up command-line so we know what was happening i.e. xia2.small_molecule

--- a/command_line/small_molecule.py
+++ b/command_line/small_molecule.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+
 import sys
 
 if __name__ == "__main__":

--- a/command_line/to_shelx.py
+++ b/command_line/to_shelx.py
@@ -8,6 +8,11 @@ import sys
 
 import iotbx.cif.model
 import xia2.XIA2Version
+from iotbx.reflection_file_reader import any_reflection_file
+from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
+from cctbx.xray import scatterer
+from iotbx.shelx import writer
+from cctbx.xray.structure import structure
 
 
 def parse_compound(compound):
@@ -141,12 +146,6 @@ Winter, G. (2010) Journal of Applied Crystallography 43
 def to_shelx(hklin, prefix, compound="", options=None):
     """Read hklin (unmerged reflection file) and generate SHELXT input file
     and HKL file"""
-
-    from iotbx.reflection_file_reader import any_reflection_file
-    from iotbx.shelx import writer
-    from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
-    from cctbx.xray.structure import structure
-    from cctbx.xray import scatterer
 
     reader = any_reflection_file(hklin)
     mtz_object = reader.file_content()

--- a/command_line/to_shelx.py
+++ b/command_line/to_shelx.py
@@ -8,11 +8,11 @@ import sys
 
 import iotbx.cif.model
 import xia2.XIA2Version
-from iotbx.reflection_file_reader import any_reflection_file
-from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
 from cctbx.xray import scatterer
-from iotbx.shelx import writer
 from cctbx.xray.structure import structure
+from iotbx.reflection_file_reader import any_reflection_file
+from iotbx.shelx import writer
+from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
 
 
 def parse_compound(compound):

--- a/command_line/to_shelxcde.py
+++ b/command_line/to_shelxcde.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
+from iotbx.reflection_file_reader import any_reflection_file
+from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
 
 
 def to_shelxcde(hklin, prefix, sites=0):
     """Read hklin (unmerged reflection file) and generate SHELXC input file
     and HKL file"""
-
-    from iotbx.reflection_file_reader import any_reflection_file
-    from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
 
     reader = any_reflection_file(hklin)
     intensities = [

--- a/command_line/to_shelxcde.py
+++ b/command_line/to_shelxcde.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
+
 from iotbx.reflection_file_reader import any_reflection_file
 from iotbx.shelx.hklf import miller_array_export_as_shelx_hklf
 


### PR DESCRIPTION
This is a subset of all float-able imports, courtesy of @ndevenish's script.
We can't float all the imports as there are some circular dependencies.
I've unfloated those files that take part in the loops.
I then ran `isort` over most of the remaining files.

Running tests now.