### PR TITLE
Only exclude outliers if resolution limit set

### DIFF
--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -67,7 +67,7 @@ xds
             "and NUMBER_OF_PROFILE_GRID_POINTS_ALONG_GAMMA."
     .type = ints(size = 2)
     .expert_level = 1
-  keep_outliers = False
+  keep_outliers = True
     .type = bool
     .short_caption = "Keep outliers"
     .help = "Do not remove outliers in integration and scaling"

--- a/Modules/Scaler/XDSScalerA.py
+++ b/Modules/Scaler/XDSScalerA.py
@@ -926,6 +926,7 @@ class XDSScalerA(Scaler):
         if (
             not PhilIndex.params.dials.fast_mode
             and not PhilIndex.params.xds.keep_outliers
+            and self.get_scaler_resolution_limits()
         ):
             xscale_remove = xscale.get_remove()
             if xscale_remove:

--- a/newsfragments/445.bugfix
+++ b/newsfragments/445.bugfix
@@ -1,0 +1,1 @@
+Changed outlier rejection in 3dii pipeline - no longer throw out outliers by default, and if outlier rejection requested only perform this after assessing resolution limits.


### PR DESCRIPTION
Otherwise we end up trying to exclude wilson outliers using
reflections that are beyond the diffraction limit, which can lead
to 100s of cycles of outlier rejection.

Fixes #388