### PR TITLE
Factor in batch offsets in imagesets

### DIFF
--- a/Schema/XSweep.py
+++ b/Schema/XSweep.py
@@ -507,9 +507,10 @@ class XSweep(object):
 
         if self._frames_to_process:
             summary.append("Images: %d to %d" % tuple(self._frames_to_process))
+            off = self._imageset.get_scan().get_batch_offset()
             first = self._frames_to_process[0]
-            start = self._frames_to_process[0] - first
-            end = self._frames_to_process[1] - first + 1
+            start = self._frames_to_process[0] - first + off
+            end = self._frames_to_process[1] - first + 1 + off
             self._imageset = self._imageset[start:end]
 
         indxr = self._get_indexer()

--- a/Schema/__init__.py
+++ b/Schema/__init__.py
@@ -220,14 +220,10 @@ def load_imagesets(
                 image_range[0] >= scan_image_range[0]
                 and image_range[1] <= scan_image_range[1]
             ):
-                imagesets = [
-                    imageset[
-                        image_range[0]
-                        - scan_image_range[0] : image_range[1]
-                        + 1
-                        - scan_image_range[0]
-                    ]
-                ]
+                b0 = scan.get_batch_offset()
+                i0 = image_range[0] - scan_image_range[0] + b0
+                i1 = image_range[1] - scan_image_range[0] + b0
+                imagesets = [imageset[i0 : i1 + 1]]
                 assert len(imagesets[0]) == image_range[1] - image_range[0] + 1, len(
                     imagesets[0]
                 )

--- a/Test/Schema/test_Schema.py
+++ b/Test/Schema/test_Schema.py
@@ -1,0 +1,20 @@
+import mock
+import sys
+
+from xia2.Schema import load_imagesets
+
+
+def test_load_imageset(dials_data, tmp_path):
+
+    with mock.patch.object(sys, "argv", []):
+
+        for j in range(1, 46):
+            if j == 23:
+                continue
+            tmp_path.joinpath(f"insulin_1_{j:03d}.img").symlink_to(
+                dials_data("insulin").join(f"insulin_1_{j:03d}.img")
+            )
+
+        imagesets = load_imagesets("insulin_1_###.img", str(tmp_path))
+        assert len(imagesets) == 2
+        assert tuple(map(len, imagesets)) == (22, 22)

--- a/newsfragments/463.bugfix
+++ b/newsfragments/463.bugfix
@@ -1,0 +1,1 @@
+Fix issue where missing images caused error: "can't convert negative value to unsigned int"


### PR DESCRIPTION
Factor in batch offsets when getting subsets of imagesets - this fixes the case
of one or so missing images in a sweep, need to verify that the other use
cases are not affected negatively by this change.

Fixes #462