### PR TITLE
Re-estimate resolution limit after deltacchalf filtering

### DIFF
--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -472,6 +472,12 @@ class MultiCrystalScale:
             scaled = Scale(data_manager, self._params, filtering=True)
             self.scale_and_filter_results = scaled.scale_and_filter_results
             logger.info("Scale and filtering:\n%s", self.scale_and_filter_results)
+            if len(data_manager.experiments) < len(self._data_manager.experiments):
+                # Some data sets have been removed, perform full re-scaling on
+                # on the subset of experiments, including re-estimation of
+                # resolution limit
+                self._params.resolution.d_min = None
+                scaled = Scale(data_manager, self._params)
             self._record_individual_report(data_manager, scaled.report(), "Filtered")
             py.path.local(scaled.scaled_unmerged_mtz).copy(
                 py.path.local("filtered_unmerged.mtz")

--- a/newsfragments/466.feature
+++ b/newsfragments/466.feature
@@ -1,0 +1,1 @@
+Re-estimate resolution limit after deltacchalf filtering. Previously the resolution limit of the filtered dataset would always be the same as the unfiltered dataset.


### PR DESCRIPTION
Sometimes the resolution of the data can improve significantly after deltacchalf filtering. Therefore if some experiments have been removed by deltacchalf filtering, perform full re-scaling of the filtered data in order to re-estimate the resolution limit.

Depends on dials/dials#1276