### PR TITLE
Increase XDS COLSPOT minimum_pixels_per_spot to 2

### DIFF
--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -160,7 +160,7 @@ xds
       .type = float(value_min=0)
   }
   colspot {
-    minimum_pixels_per_spot = 1
+    minimum_pixels_per_spot = 2
       .short_caption = "For PAD MINIMUM_NUMBER_OF_PIXELS_IN_A_SPOT ="
       .type = int
       .expert_level = 1

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -265,7 +265,7 @@ dials
     threshold.algorithm = dispersion dispersion_extended
       .type = choice
       .expert_level = 2
-    min_spot_size = Auto
+    min_spot_size = None
       .type = int
       .help = "The minimum number of contiguous pixels for a spot to be " \
               "accepted by the filtering algorithm."

--- a/Modules/Indexer/DialsIndexer.py
+++ b/Modules/Indexer/DialsIndexer.py
@@ -312,11 +312,6 @@ class DialsIndexer(Indexer):
                 spotfinder.set_scan_ranges([(first, last)])
             if dfs_params.phil_file is not None:
                 spotfinder.set_phil_file(dfs_params.phil_file)
-            if dfs_params.min_spot_size is libtbx.Auto:
-                if imageset.get_detector()[0].get_type() == "SENSOR_PAD":
-                    dfs_params.min_spot_size = 3
-                else:
-                    dfs_params.min_spot_size = None
             if dfs_params.min_spot_size is not None:
                 spotfinder.set_min_spot_size(dfs_params.min_spot_size)
             if dfs_params.min_local is not None:

--- a/Wrappers/XDS/XDSColspot.py
+++ b/Wrappers/XDS/XDSColspot.py
@@ -88,24 +88,6 @@ def XDSColspot(DriverType=None, params=None):
 
         def run(self):
             """Run colspot."""
-
-            # image_header = self.get_header()
-
-            ## crank through the header dictionary and replace incorrect
-            ## information with updated values through the indexer
-            ## interface if available...
-
-            ## need to add distance, wavelength - that should be enough...
-
-            # if self.get_distance():
-            # image_header['distance'] = self.get_distance()
-
-            # if self.get_wavelength():
-            # image_header['wavelength'] = self.get_wavelength()
-
-            # if self.get_two_theta():
-            # image_header['two_theta'] = self.get_two_theta()
-
             header = imageset_to_xds(self.get_imageset())
 
             xds_inp = open(os.path.join(self.get_working_directory(), "XDS.INP"), "w")
@@ -115,7 +97,6 @@ def XDSColspot(DriverType=None, params=None):
             xds_inp.write("MAXIMUM_NUMBER_OF_PROCESSORS=%d\n" % self._parallel)
             xds_inp.write("MAXIMUM_NUMBER_OF_JOBS=1\n")
 
-            # if image_header['detector'] in ('pilatus', 'dectris'):
             if self.get_imageset().get_detector()[0].get_type() == "SENSOR_PAD":
                 xds_inp.write(
                     "MINIMUM_NUMBER_OF_PIXELS_IN_A_SPOT=%d\n"

--- a/newsfragments/472.bugfix
+++ b/newsfragments/472.bugfix
@@ -1,0 +1,1 @@
+Increase XDS COLSPOT minimum_pixels_per_spot to 2. The previous value of minimum_pixels_per_spot=1 may lead to problems when spotfinding on images with many hot/warm pixels.


### PR DESCRIPTION
The previous value of minimum_pixels_per_spot=1 may lead to problems when spotfinding on images with many hot/warm pixels, so increase the minimum size.

Example data set:

`xia2 pipeline=3dii atom=S read_all_image_headers=False trust_beam_centre=True image=/dls/i23/data/2020/cm26461-3/20200616/lyso_1_2p9keV/data_1_00001.cbf`

With the current default:
```
$ grep "NUMBER OF STRONG PIXELS EXTRACTED" -A 5 DEFAULT/SAD/SWEEP1/index/3_COLSPOT.LP 
 NUMBER OF STRONG PIXELS EXTRACTED FROM IMAGES     1513468

 NUMBER OF DIFFRACTION SPOTS LOCATED                488147
 IGNORED BECAUSE OF SPOT CLOSE TO UNTRUSTED REGION   97170
 WEAK SPOTS OMITTED                                      0
 NUMBER OF DIFFRACTION SPOTS ACCEPTED               390977
```

Setting `minimum_pixels_per_spot=2`:
```
$ grep "NUMBER OF STRONG PIXELS EXTRACTED" -A 5 DEFAULT/SAD/SWEEP1/index/3_COLSPOT.LP 
 NUMBER OF STRONG PIXELS EXTRACTED FROM IMAGES     1513468

 NUMBER OF DIFFRACTION SPOTS LOCATED                109220
 IGNORED BECAUSE OF SPOT CLOSE TO UNTRUSTED REGION   22248
 WEAK SPOTS OMITTED                                      0
 NUMBER OF DIFFRACTION SPOTS ACCEPTED                86972
```

Alternatively, setting it to `minimum_pixels_per_spot=3` (the XDS default):
```
$ grep "NUMBER OF STRONG PIXELS EXTRACTED" -A 5 DEFAULT/SAD/SWEEP1/index/3_COLSPOT.LP 
 NUMBER OF STRONG PIXELS EXTRACTED FROM IMAGES     1513468

 NUMBER OF DIFFRACTION SPOTS LOCATED                 67362
 IGNORED BECAUSE OF SPOT CLOSE TO UNTRUSTED REGION   13831
 WEAK SPOTS OMITTED                                      0
 NUMBER OF DIFFRACTION SPOTS ACCEPTED                53531
```