### PR TITLE
Gracefully handle xtriage error

### DIFF
--- a/command_line/html.py
+++ b/command_line/html.py
@@ -102,12 +102,9 @@ def generate_xia2_html(xinfo, filename="xia2.html", params=None, args=[]):
                         xtriage_danger,
                     ) = report.xtriage_report()
                 except Exception as e:
-                    from xia2.Handlers.Phil import PhilIndex
-
-                    if PhilIndex.params.xia2.settings.small_molecule:
-                        print("Xtriage output not available: %s" % str(e))
-                    else:
-                        raise
+                    params.xtriage_analysis = False
+                    logger.debug("Exception running xtriage:")
+                    logger.debug(e, exc_info=True)
 
             (
                 overall_stats_table,

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -52,7 +52,12 @@ def run(args):
     # xtriage
     xtriage_success, xtriage_warnings, xtriage_danger = None, None, None
     if params.xtriage_analysis:
-        xtriage_success, xtriage_warnings, xtriage_danger = report.xtriage_report()
+        try:
+            xtriage_success, xtriage_warnings, xtriage_danger = report.xtriage_report()
+        except Exception as e:
+            params.xtriage_analysis = False
+            print("Exception runnning xtriage:")
+            print(e)
 
     json_data = {}
 

--- a/newsfragments/477.bugfix
+++ b/newsfragments/477.bugfix
@@ -1,0 +1,1 @@
+Gracefully handle xtriage errors when generating xia2 report.


### PR DESCRIPTION
xtriage can sometimes fail (e.g. during twin analyses), particularly in the case of severly incomplete data sets. Since the xtriage analysis is a "nice to have" rather than "essential" part of the xia2 output, don't fail outright, instead recording the exception in xia2-debug.txt