### PR TITLE
Plot bin centres in compare_merging_stats

### DIFF
--- a/command_line/compare_merging_stats.py
+++ b/command_line/compare_merging_stats.py
@@ -249,10 +249,15 @@ def plot_data(
                     other = (other,)
                 for res in other:
                     if res is not None:
-                        bins = res.bins
-                        x = [bins[j].d_min for j in range(len(bins))]
-                        x = [uctbx.d_as_d_star_sq(d) for d in x]
-                        y = [getattr(bins[j], k) for j in range(len(bins))]
+                        x = [
+                            0.5
+                            * (
+                                uctbx.d_as_d_star_sq(b.d_max)
+                                + uctbx.d_as_d_star_sq(b.d_min)
+                            )
+                            for b in res.bins
+                        ]
+                        y = [getattr(b, k) for b in res.bins]
                         ax.plot(
                             x, y, linestyle="-", color="grey", linewidth=1, alpha=alpha,
                         )
@@ -265,10 +270,12 @@ def plot_data(
                     l = global_labels[i_res]
                 else:
                     l = label
-                bins = res.bins
-                x = [bins[j].d_min for j in range(len(bins))]
-                x = [uctbx.d_as_d_star_sq(d) for d in x]
-                y = [getattr(bins[j], k) for j in range(len(bins))]
+                x = [
+                    0.5
+                    * (uctbx.d_as_d_star_sq(b.d_max) + uctbx.d_as_d_star_sq(b.d_min))
+                    for b in res.bins
+                ]
+                y = [getattr(b, k) for b in res.bins]
                 color = colors[i_res] if n_cols > 1 else colors[i]
                 ax.plot(x, y, label=l, linestyle=linestyle, color=color)
 

--- a/newsfragments/480.bugfix
+++ b/newsfragments/480.bugfix
@@ -1,0 +1,1 @@
+xia2.compare_merging_stats: Plot the bin centres rather than bin d_min values. This previously could lead to misleading apparent differences between data sets with significantly different resolution limits.


### PR DESCRIPTION
Previously bin.d_min alone was used to determine the x-coordinate, which meant that the resulting plots could be misleading,
especially when comparing data sets at significantly different resolution limits. Now the average of bin d_star_sq limits is used as the x-coordinate.

Example data set (Mpro-0165) where there looked to be a significant (i.e. worse) difference between scaling results after application of a resolution cutoff:
![image](https://user-images.githubusercontent.com/2810624/86500150-1643d400-bd87-11ea-8545-41da1542ac1d.png)

However, when plotting instead the bin centres as the x-coordinate, there is no such obvious gap between the two curves:
![image](https://user-images.githubusercontent.com/2810624/86500179-41c6be80-bd87-11ea-9e0f-704ccb09eb07.png)

This is clearer when applying the same resolution cutoff to both data sets to ensure that the same resolution bins are used for both data sets:
![image](https://user-images.githubusercontent.com/2810624/86500218-89e5e100-bd87-11ea-8ab2-b10299d8d2c1.png)
