### PR TITLE
Read file as text not binary

### DIFF
--- a/command_line/ispyb_xml.py
+++ b/command_line/ispyb_xml.py
@@ -15,7 +15,7 @@ def ispyb_xml(xml_out):
     for record in open("xia2.txt"):
         if record.startswith("Command line:"):
             command_line = record.replace("Command line:", "").strip()
-    with open("xia2-working.phil", "rb") as f:
+    with open("xia2-working.phil", "r") as f:
         working_phil = iotbx.phil.parse(f.read())
     xinfo = XProject.from_json(filename="xia2.json")
     crystals = xinfo.get_crystals()


### PR DESCRIPTION
Reads the working PHIL file, but reading this as binary breaks the phil
parsing as the data are a byte array on Python 3 - open as text seems to
fix this - fixes #483