### PR TITLE
Accept multiple reference instrument models in a single file

### DIFF
--- a/Schema/__init__.py
+++ b/Schema/__init__.py
@@ -260,14 +260,15 @@ def load_reference_geometries(geometry_file_list):
             # as per dials.show, rather than the UID string of the experiment.
             logger.debug(f"Experiment {b[3]} of {b[2]} is a duplicate.")
         else:
-            unique.update((a, b))
+            unique.add(a)
+            unique.add(b)
 
     n = len(unique)
     logger.debug(f"Found {n} unique reference geometr{'ies' if n != 1 else 'y'}.")
     for geometry in unique:
         logger.debug(f"Experiment {geometry[3]} of {geometry[2]} is unique.")
 
-    return [dict(zip(("detector", "beam"), components[:2])) for components in unique]
+    return [{"detector": components[0], "beam": components[1]} for components in unique]
 
 
 def compare_geometries(detectorA, detectorB):

--- a/Schema/__init__.py
+++ b/Schema/__init__.py
@@ -4,10 +4,9 @@ import itertools
 import logging
 import os
 
+from dxtbx.model import ExperimentList
 from scitbx.array_family import flex
-
 from xia2.Handlers.Phil import PhilIndex
-
 
 logger = logging.getLogger("xia2.Schema")
 
@@ -246,34 +245,29 @@ def update_with_reference_geometry(imagesets, reference_geometry_list):
 
 
 def load_reference_geometries(geometry_file_list):
-    from dxtbx.serialize import load
+    logger.debug("Collecting reference instrument models.")
+    ref_components = [
+        (expt.detector, expt.beam, f, i)
+        for f in geometry_file_list
+        for i, expt in enumerate(ExperimentList.from_file(f, check_format=False))
+    ]
 
-    reference_components = []
-    for file in geometry_file_list:
-        try:
-            experiments = load.experiment_list(file, check_format=False)
-            assert len(experiments.detectors()) == 1
-            assert len(experiments.beams()) == 1
-            reference_detector = experiments.detectors()[0]
-            reference_beam = experiments.beams()[0]
-        except Exception:
-            experiments = load.experiment_list(file)
-            imageset = experiments.imagesets()[0]
-            reference_detector = imageset.get_detector()
-            reference_beam = imageset.get_beam()
-        reference_components.append(
-            {"detector": reference_detector, "beam": reference_beam, "file": file}
-        )
+    logger.debug("Removing duplicate reference geometries.")
+    unique = set()
+    for a, b in filter(unique.isdisjoint, itertools.combinations(ref_components, 2)):
+        if compare_geometries(a[0], b[0]):
+            # Note that expt_index is the index of the experiment in the expt list file,
+            # as per dials.show, rather than the UID string of the experiment.
+            logger.debug(f"Experiment {b[3]} of {b[2]} is a duplicate.")
+        else:
+            unique.update((a, b))
 
-    for combination in itertools.combinations(reference_components, 2):
-        if compare_geometries(combination[0]["detector"], combination[1]["detector"]):
-            logger.error(
-                "Reference geometries given in %s and %s are too similar"
-                % combination[0]["file"],
-                combination[1]["file"],
-            )
-            raise Exception("Reference geometries too similar")
-    return reference_components
+    n = len(unique)
+    logger.debug(f"Found {n} unique reference geometr{'ies' if n != 1 else 'y'}.")
+    for geometry in unique:
+        logger.debug(f"Experiment {geometry[3]} of {geometry[2]} is unique.")
+
+    return [dict(zip(("detector", "beam"), components[:2])) for components in unique]
 
 
 def compare_geometries(detectorA, detectorB):

--- a/Test/Schema/test_Schema.py
+++ b/Test/Schema/test_Schema.py
@@ -33,7 +33,7 @@ def test_load_reference_geometries(dials_data):
 
     # Check that there are four input instrument models, of which only two are unique.
     assert (
-        sum([len(ExperimentList.from_file(f, check_format=False)) for f in files]) == 4
+        sum(len(ExperimentList.from_file(f, check_format=False)) for f in files) == 4
     ), "Expected to find four experiments, one for each sweep."
     assert (
         len(load_reference_geometries(files)) == 2

--- a/Test/Schema/test_Schema.py
+++ b/Test/Schema/test_Schema.py
@@ -1,7 +1,8 @@
 import mock
 import sys
 
-from xia2.Schema import load_imagesets
+from dxtbx.model import ExperimentList
+from xia2.Schema import load_imagesets, load_reference_geometries
 
 
 def test_load_imageset(dials_data, tmp_path):
@@ -18,3 +19,22 @@ def test_load_imageset(dials_data, tmp_path):
         imagesets = load_imagesets("insulin_1_###.img", str(tmp_path))
         assert len(imagesets) == 2
         assert tuple(map(len, imagesets)) == (22, 22)
+
+
+def test_load_reference_geometries(dials_data):
+    """
+    Test `xia2.Schema.load_reference_geometries`.
+
+    Test the function that finds the set of unique instrument models from a list
+    of experiment list files.
+    """
+    files = ["scaled_20_25.expt", "scaled_30.expt", "scaled_35.expt"]
+    files = [(dials_data("l_cysteine_4_sweeps_scaled") / f).strpath for f in files]
+
+    # Check that there are four input instrument models, of which only two are unique.
+    assert (
+        sum([len(ExperimentList.from_file(f, check_format=False)) for f in files]) == 4
+    ), "Expected to find four experiments, one for each sweep."
+    assert (
+        len(load_reference_geometries(files)) == 2
+    ), "Expected to find two unique instrument models."

--- a/newsfragments/485.bugfix
+++ b/newsfragments/485.bugfix
@@ -1,0 +1,7 @@
+The treatment of reference instrument models with the command-line argument ``reference_geometry=`` has been improved.
+
+Previously, one needed to pass a separate 'experiment list' (``.expt``) file for each instrument model.
+If any of the files contained multiple instrument models (if they had been created from multiple-sweep rotation data, for example), xia2 was a bit fragile and could sometimes fail with an erroneous message "no sweeps found".
+
+Now, one can pass any number of ``.expt`` files with ``reference_geometry=`` arguments and each file may contain any number of instrument models.
+xia2 will sort out any duplicate models for you.


### PR DESCRIPTION
At present, xia2 expects that each `reference_geometry=` argument passed at the command line consists of a experiment list `.expt` file containing just one experiment.  If the file contains multiple experiments, two undesirable things happen:
* The experiment list is loaded from file with `check_format=True`, which leaves xia2 exposed to `FileNotFoundError`s when reference instrument models contain invalid references to hot mask files and/or image templates.
* If the experiment list is loaded successfully, only the first experiment is used and the others are discarded.

Here, I introduce a new workflow:
1. Always load reference instrument model experiment lists with `check_format=False`, since we have no interest in creating an imageset and don't want to be troubled by broken file references.
2. Aggregate all the experiments from experiment lists passed as instrument models with `reference_geometry=`.
3. Remove equivalent instrument models to produce a minimal set of unique reference instrument models.