### PR TITLE
DIALS 2.2.8

### DIFF
--- a/Handlers/CommandLine.py
+++ b/Handlers/CommandLine.py
@@ -58,7 +58,7 @@ def unroll_parameters(hdf5_master):
             root = master["/entry/instrument/detector"]
             ntrigger = root["detectorSpecific/ntrigger"][()]
             nimages = root["detectorSpecific/nimages"][()]
-        if ntrigger > 1:
+        if ntrigger > 1 and nimages > 1:
             return ntrigger, nimages
     except Exception:
         return None

--- a/command_line/ispyb_xml.py
+++ b/command_line/ispyb_xml.py
@@ -17,7 +17,7 @@ def ispyb_xml(xml_out):
     for record in open("xia2.txt"):
         if record.startswith("Command line:"):
             command_line = record.replace("Command line:", "").strip()
-    with open("xia2-working.phil", "rb") as f:
+    with open("xia2-working.phil", "r") as f:
         working_phil = iotbx.phil.parse(f.read())
     xinfo = XProject.from_json(filename="xia2.json")
     crystals = xinfo.get_crystals()

--- a/newsfragments/475.bugfix
+++ b/newsfragments/475.bugfix
@@ -1,0 +1,1 @@
+Fix data from NSLS II with multiple triggers and one image per trigger


### PR DESCRIPTION
* `xia2`: fix reading data from NSLS II with multiple triggers and one image per trigger (#475)
* `xia2.ispyb_xml`: fix crash on Python 3 (#483)