### PR TITLE
Pass image_range to ExperimentListTemplateImporter

### DIFF
--- a/Schema/__init__.py
+++ b/Schema/__init__.py
@@ -7,7 +7,6 @@ import os
 from dxtbx.model import ExperimentList
 from dxtbx.model.experiment_list import ExperimentListTemplateImporter
 from scitbx.array_family import flex
-from xia2.Handlers.CommandLine import CommandLine
 from xia2.Handlers.Phil import PhilIndex
 
 
@@ -149,6 +148,8 @@ def load_imagesets(
                 )
 
             else:
+                from xia2.Handlers.CommandLine import CommandLine
+
                 experiments = ExperimentList()
                 start_ends = CommandLine.get_start_ends(full_template_path)
                 if not start_ends:

--- a/Schema/__init__.py
+++ b/Schema/__init__.py
@@ -5,8 +5,11 @@ import logging
 import os
 
 from dxtbx.model import ExperimentList
+from dxtbx.model.experiment_list import ExperimentListTemplateImporter
 from scitbx.array_family import flex
+from xia2.Handlers.CommandLine import CommandLine
 from xia2.Handlers.Phil import PhilIndex
+
 
 logger = logging.getLogger("xia2.Schema")
 
@@ -146,12 +149,17 @@ def load_imagesets(
                 )
 
             else:
-                from dxtbx.model.experiment_list import ExperimentListTemplateImporter
-
-                importer = ExperimentListTemplateImporter(
-                    [full_template_path], format_kwargs=format_kwargs
-                )
-                experiments = importer.experiments
+                experiments = ExperimentList()
+                start_ends = CommandLine.get_start_ends(full_template_path)
+                if not start_ends:
+                    start_ends.append(None)
+                for image_range in start_ends:
+                    importer = ExperimentListTemplateImporter(
+                        [full_template_path],
+                        format_kwargs=format_kwargs,
+                        image_range=image_range,
+                    )
+                    experiments.extend(importer.experiments)
 
         imagesets = [
             iset for iset in experiments.imagesets() if isinstance(iset, ImageSequence)

--- a/newsfragments/491.bugfix
+++ b/newsfragments/491.bugfix
@@ -1,0 +1,1 @@
+Don't fail with complaint about missing images if they lie outside the start:end specified on the command line when used in combination with read_image_headers=False.


### PR DESCRIPTION
This means that xia2 doesn't complain about missing images if they lie outside the start:end specified on the command line.
Only affects read_image_headers=False (i.e. loading the dxtbx imageset from a template).

Fixes #490.

See also cctbx/dxtbx#191 and dials/dials#1333.