### PR TITLE
Adapt for resolutionizer rename

### DIFF
--- a/Driver/test_timing.py
+++ b/Driver/test_timing.py
@@ -111,7 +111,7 @@ def test_timing_visualisation():
             "time_start": 1555579136.769065,
         },
         {
-            "command": "xia2.resolutionizer  'AUTOMATIC_DEFAULT_scaled_test_unmerged.mtz' 'nbins=100' 'rmerge=None' 'completeness=None' 'cc_half=0.3' 'cc_half_fit=tanh' 'cc_half_significance_level=0.1' 'isigma=0.25' 'misigma=1.0' 'batch_range=1,300'",
+            "command": "dials.estimate_resolution  'AUTOMATIC_DEFAULT_scaled_test_unmerged.mtz' 'nbins=100' 'rmerge=None' 'completeness=None' 'cc_half=0.3' 'cc_half_fit=tanh' 'cc_half_significance_level=0.1' 'isigma=0.25' 'misigma=1.0' 'batch_range=1,300'",
             "details": {
                 "object initialization": 1555579138.586713,
                 "process start": 1555579138.589566,

--- a/Handlers/Phil.py
+++ b/Handlers/Phil.py
@@ -978,7 +978,7 @@ xia2.settings
     process_includes=True,
 )
 
-# override default resolutionizer parameters
+# override default resolution parameters
 master_phil = master_phil.fetch(
     source=parse(
         """\

--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -101,7 +101,7 @@ resolution
     .type = float(value_min=0.0)
     .help = "High resolution cutoff."
     .short_caption = "High resolution cutoff"
-  include scope dials.util.resolutionizer.phil_str
+  include scope dials.util.resolution_analysis.phil_str
 }
 
 filtering {

--- a/Wrappers/XIA/Merger.py
+++ b/Wrappers/XIA/Merger.py
@@ -13,7 +13,7 @@ def Merger(DriverType=None):
     class MergerWrapper(DriverInstance.__class__):
         def __init__(self):
             DriverInstance.__class__.__init__(self)
-            self.set_executable("dials.resolutionizer")
+            self.set_executable("dials.estimate_resolution")
 
             # inputs
             self._hklin = None

--- a/newsfragments/492.bugfix
+++ b/newsfragments/492.bugfix
@@ -1,0 +1,1 @@
+Modifications to cope with dials resolution estimation rename


### PR DESCRIPTION
Following https://github.com/dials/dials/commit/d064f022f64885bcb9040563ec45decbc2152df7 xia2 is broken in a couple of places => working through to try and fix... 

N.B. reverted d33f60e363a8adc2c350b22a7105403d84eb40f6 on master as it was part of this work, so when squash merging all the changes go in one commit... 