### PR TITLE
Fix load_imagesets introduced by #491

### DIFF
--- a/Applications/xia2setup.py
+++ b/Applications/xia2setup.py
@@ -306,9 +306,14 @@ def _write_sweeps(sweeps, out):
     for sweep in sweeplist:
         sweeps = _known_sweeps[sweep]
 
-        # sort on exposure epoch
-        epochs = [s.get_imageset().get_scan().get_epochs()[0] for s in sweeps]
-        sweeps = [s for _, s in sorted(zip(epochs, sweeps))]
+        # sort on exposure epoch followed by first image number
+        sweeps = sorted(
+            sweeps,
+            key=lambda s: (
+                s.get_imageset().get_scan().get_epochs()[0],
+                s.get_images()[0],
+            ),
+        )
         for s in sweeps:
             if len(s.get_images()) < min_images:
                 logger.debug("Rejecting sweep %s:" % s.get_template())
@@ -424,9 +429,14 @@ def _write_sweeps(sweeps, out):
     for sweep in sweeplist:
         sweeps = _known_sweeps[sweep]
 
-        # sort on exposure epoch
-        epochs = [s.get_imageset().get_scan().get_epochs()[0] for s in sweeps]
-        sweeps = [s for _, s in sorted(zip(epochs, sweeps))]
+        # sort on exposure epoch followed by first image number
+        sweeps = sorted(
+            sweeps,
+            key=lambda s: (
+                s.get_imageset().get_scan().get_epochs()[0],
+                s.get_images()[0],
+            ),
+        )
 
         for s in sweeps:
             # require at least n images to represent a sweep...

--- a/Schema/__init__.py
+++ b/Schema/__init__.py
@@ -154,11 +154,11 @@ def load_imagesets(
                 start_ends = CommandLine.get_start_ends(full_template_path)
                 if not start_ends:
                     start_ends.append(None)
-                for image_range in start_ends:
+                for start_end in start_ends:
                     importer = ExperimentListTemplateImporter(
                         [full_template_path],
                         format_kwargs=format_kwargs,
-                        image_range=image_range,
+                        image_range=start_end,
                     )
                     experiments.extend(importer.experiments)
 

--- a/Test/Applications/test_xia2setup.py
+++ b/Test/Applications/test_xia2setup.py
@@ -21,10 +21,14 @@ def test_write_xinfo_split_sweep(dials_data, tmp_path, monkeypatch):
             "read_all_image_headers=False",
         ],
     ):
-        # Force reload of CommandLine singleton object with the parameters above
+        # Force reload of various singleton objects with the parameters above
         import xia2.Handlers.CommandLine
+        import xia2.Applications.xia2setup
+        import xia2.Schema
 
         reload(xia2.Handlers.CommandLine)
+        reload(xia2.Applications.xia2setup)
+        xia2.Schema.imageset_cache = xia2.Schema._ImagesetCache()
 
         template = xia2.Handlers.CommandLine.CommandLine.get_template()
         directories = [os.path.split(p) for p in template]
@@ -37,5 +41,40 @@ def test_write_xinfo_split_sweep(dials_data, tmp_path, monkeypatch):
         assert xinfo.exists()
         x = XInfo(xinfo)
         assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 2
-        x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 22]
-        x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [23, 45]
+        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 22]
+        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [23, 45]
+
+
+def test_write_xinfo_unroll(dials_data, tmp_path):
+    # This test partially exercises the fix to https://github.com/xia2/xia2/issues/498 with a different syntax
+    xinfo = tmp_path.joinpath("unroll.xinfo")
+
+    with mock.patch.object(
+        sys,
+        "argv",
+        [
+            f"image={dials_data('insulin').join('insulin_1_001.img:1:45:15')}",
+            "read_all_image_headers=False",
+        ],
+    ):
+        # Force reload of various singleton objects with the parameters above
+        import xia2.Handlers.CommandLine
+        import xia2.Applications.xia2setup
+        import xia2.Schema
+
+        reload(xia2.Handlers.CommandLine)
+        reload(xia2.Applications.xia2setup)
+        xia2.Schema.imageset_cache = xia2.Schema._ImagesetCache()
+
+        template = xia2.Handlers.CommandLine.CommandLine.get_template()
+        directories = [os.path.split(p) for p in template]
+
+        xia2.Applications.xia2setup.write_xinfo(
+            xinfo, directories, template=template,
+        )
+        assert xinfo.exists()
+        x = XInfo(xinfo)
+        assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 3
+        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 15]
+        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [16, 30]
+        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP3"]["start_end"] == [31, 45]

--- a/Test/Applications/test_xia2setup.py
+++ b/Test/Applications/test_xia2setup.py
@@ -12,6 +12,7 @@ def test_write_xinfo_split_sweep(dials_data, tmpdir):
             "read_all_image_headers=False",
         ],
         working_directory=tmpdir,
+        environment_override={"CCP4": tmpdir},
     )
     assert not result.returncode
     assert not result.stderr
@@ -32,6 +33,7 @@ def test_write_xinfo_unroll(dials_data, tmpdir):
             "read_all_image_headers=False",
         ],
         working_directory=tmpdir,
+        environment_override={"CCP4": tmpdir},
     )
     assert not result.returncode
     assert not result.stderr

--- a/Test/Applications/test_xia2setup.py
+++ b/Test/Applications/test_xia2setup.py
@@ -6,8 +6,10 @@ from importlib import reload
 from xia2.Handlers.XInfo import XInfo
 
 
-def test_write_xinfo_split_sweep(dials_data, tmp_path):
-    # This test partially exercises the fix to https://github.com/xia2/xia2/issues/498
+def test_write_xinfo_split_sweep(dials_data, tmp_path, monkeypatch):
+    # This test partially exercises the fix to xia2/xia2#498
+    # run in tmp dir so droppings not cluttering source area
+    monkeypatch.chdir(tmp_path)
     xinfo = tmp_path.joinpath("test.xinfo")
 
     with mock.patch.object(

--- a/Test/Applications/test_xia2setup.py
+++ b/Test/Applications/test_xia2setup.py
@@ -1,0 +1,39 @@
+import mock
+import os
+import sys
+from importlib import reload
+
+from xia2.Handlers.XInfo import XInfo
+
+
+def test_write_xinfo_split_sweep(dials_data, tmp_path):
+    # This test partially exercises the fix to https://github.com/xia2/xia2/issues/498
+    xinfo = tmp_path.joinpath("test.xinfo")
+
+    with mock.patch.object(
+        sys,
+        "argv",
+        [
+            f"image={dials_data('insulin').join('insulin_1_001.img:1:22')}",
+            f"image={dials_data('insulin').join('insulin_1_001.img:23:45')}",
+            "read_all_image_headers=False",
+        ],
+    ):
+        # Force reload of CommandLine singleton object with the parameters above
+        import xia2.Handlers.CommandLine
+
+        reload(xia2.Handlers.CommandLine)
+
+        template = xia2.Handlers.CommandLine.CommandLine.get_template()
+        directories = [os.path.split(p) for p in template]
+
+        from xia2.Applications.xia2setup import write_xinfo
+
+        write_xinfo(
+            xinfo, directories, template=template,
+        )
+        assert xinfo.exists()
+        x = XInfo(xinfo)
+        assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 2
+        x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 22]
+        x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [23, 45]

--- a/Test/Applications/test_xia2setup.py
+++ b/Test/Applications/test_xia2setup.py
@@ -1,79 +1,44 @@
-import mock
-import os
-import sys
-from importlib import reload
+import procrunner
 
 from xia2.Handlers.XInfo import XInfo
 
 
-def test_write_xinfo_split_sweep(dials_data, run_in_tmpdir):
-    # This test partially exercises the fix to xia2/xia2#498
-    # run in tmp dir so droppings not cluttering source area
-    xinfo = run_in_tmpdir.join("test.xinfo")
-
-    with mock.patch.object(
-        sys,
-        "argv",
+def test_write_xinfo_split_sweep(dials_data, tmpdir):
+    result = procrunner.run(
         [
+            "xia2.setup",
             f"image={dials_data('insulin').join('insulin_1_001.img:1:22')}",
             f"image={dials_data('insulin').join('insulin_1_001.img:23:45')}",
             "read_all_image_headers=False",
         ],
-    ):
-        # Force reload of various singleton objects with the parameters above
-        import xia2.Handlers.CommandLine
-        import xia2.Applications.xia2setup
-        import xia2.Schema
-
-        reload(xia2.Handlers.CommandLine)
-        reload(xia2.Applications.xia2setup)
-        xia2.Schema.imageset_cache = xia2.Schema._ImagesetCache()
-
-        template = xia2.Handlers.CommandLine.CommandLine.get_template()
-        directories = [os.path.split(p) for p in template]
-
-        from xia2.Applications.xia2setup import write_xinfo
-
-        write_xinfo(
-            xinfo, directories, template=template,
-        )
-        assert xinfo.exists()
-        x = XInfo(xinfo)
-        assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 2
-        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 22]
-        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [23, 45]
+        working_directory=tmpdir,
+    )
+    assert not result.returncode
+    assert not result.stderr
+    xinfo = tmpdir.join("automatic.xinfo")
+    assert xinfo.check(file=1)
+    x = XInfo(xinfo)
+    assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 2
+    assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 22]
+    assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [23, 45]
 
 
-def test_write_xinfo_unroll(dials_data, run_in_tmpdir):
+def test_write_xinfo_unroll(dials_data, tmpdir):
     # This test partially exercises the fix to https://github.com/xia2/xia2/issues/498 with a different syntax
-    xinfo = run_in_tmpdir.join("unroll.xinfo")
-
-    with mock.patch.object(
-        sys,
-        "argv",
+    result = procrunner.run(
         [
+            "xia2.setup",
             f"image={dials_data('insulin').join('insulin_1_001.img:1:45:15')}",
             "read_all_image_headers=False",
         ],
-    ):
-        # Force reload of various singleton objects with the parameters above
-        import xia2.Handlers.CommandLine
-        import xia2.Applications.xia2setup
-        import xia2.Schema
-
-        reload(xia2.Handlers.CommandLine)
-        reload(xia2.Applications.xia2setup)
-        xia2.Schema.imageset_cache = xia2.Schema._ImagesetCache()
-
-        template = xia2.Handlers.CommandLine.CommandLine.get_template()
-        directories = [os.path.split(p) for p in template]
-
-        xia2.Applications.xia2setup.write_xinfo(
-            xinfo, directories, template=template,
-        )
-        assert xinfo.exists()
-        x = XInfo(xinfo)
-        assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 3
-        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 15]
-        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [16, 30]
-        assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP3"]["start_end"] == [31, 45]
+        working_directory=tmpdir,
+    )
+    assert not result.returncode
+    assert not result.stderr
+    xinfo = tmpdir.join("automatic.xinfo")
+    assert xinfo.check(file=1)
+    x = XInfo(xinfo)
+    assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 3
+    assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 15]
+    assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [16, 30]
+    assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP3"]["start_end"] == [31, 45]

--- a/Test/Applications/test_xia2setup.py
+++ b/Test/Applications/test_xia2setup.py
@@ -6,11 +6,10 @@ from importlib import reload
 from xia2.Handlers.XInfo import XInfo
 
 
-def test_write_xinfo_split_sweep(dials_data, tmp_path, monkeypatch):
+def test_write_xinfo_split_sweep(dials_data, run_in_tmpdir):
     # This test partially exercises the fix to xia2/xia2#498
     # run in tmp dir so droppings not cluttering source area
-    monkeypatch.chdir(tmp_path)
-    xinfo = tmp_path.joinpath("test.xinfo")
+    xinfo = run_in_tmpdir.join("test.xinfo")
 
     with mock.patch.object(
         sys,
@@ -45,9 +44,9 @@ def test_write_xinfo_split_sweep(dials_data, tmp_path, monkeypatch):
         assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [23, 45]
 
 
-def test_write_xinfo_unroll(dials_data, tmp_path):
+def test_write_xinfo_unroll(dials_data, run_in_tmpdir):
     # This test partially exercises the fix to https://github.com/xia2/xia2/issues/498 with a different syntax
-    xinfo = tmp_path.joinpath("unroll.xinfo")
+    xinfo = run_in_tmpdir.join("unroll.xinfo")
 
     with mock.patch.object(
         sys,

--- a/Test/Schema/test_Schema.py
+++ b/Test/Schema/test_Schema.py
@@ -53,6 +53,27 @@ def test_load_imageset_template_missing_images(insulin_with_missing_image):
         assert imagesets[0].get_array_range() == (0, 22)
 
 
+def test_load_imageset_split_sweep(dials_data):
+    directory = dials_data("insulin")
+    with mock.patch.object(
+        sys,
+        "argv",
+        [
+            f"image={directory.join('insulin_1_001.img:1:22')}",
+            f"image={directory.join('insulin_1_001.img:23:45')}",
+            "read_all_image_headers=False",
+        ],
+    ):
+        # Force reload of CommandLine singleton object with the parameters above
+        import xia2.Handlers.CommandLine
+
+        reload(xia2.Handlers.CommandLine)
+        imagesets = load_imagesets(directory.join("insulin_1_###.img"), str(directory))
+        assert len(imagesets) == 2
+        assert imagesets[0].get_array_range() == (0, 22)
+        assert imagesets[1].get_array_range() == (22, 45)
+
+
 def test_load_reference_geometries(dials_data):
     """
     Test `xia2.Schema.load_reference_geometries`.

--- a/command_line/setup.py
+++ b/command_line/setup.py
@@ -1,0 +1,100 @@
+import logging
+import os
+import sys
+import traceback
+
+from dials.util import Sorry
+from dials.util.version import dials_version
+import xia2.Driver.timing
+import xia2.Handlers.Streams
+import xia2.XIA2Version
+from xia2.Applications.xia2_main import (
+    check_environment,
+    get_command_line,
+    help,
+)
+from xia2.command_line.xia2_main import get_ccp4_version
+from xia2.Handlers.Citations import Citations
+
+logger = logging.getLogger("xia2.command_line.setup")
+
+
+def xia2_setup():
+    """Actually process something..."""
+    Citations.cite("xia2")
+
+    # print versions of related software
+    logger.info(dials_version())
+
+    ccp4_version = get_ccp4_version()
+    if ccp4_version:
+        logger.info("CCP4 %s", ccp4_version)
+
+    CommandLine = get_command_line()
+
+    # check that something useful has been assigned for processing...
+    xtals = CommandLine.get_xinfo().get_crystals()
+
+    for name, xtal in xtals.items():
+        if not xtal.get_all_image_names():
+            logger.info("-----------------------------------" + "-" * len(name))
+            logger.info("| No images assigned for crystal %s |", name)
+            logger.info("-----------------------------------" + "-" * len(name))
+
+    from xia2.Handlers.Phil import PhilIndex
+
+    params = PhilIndex.get_python_object()
+    xinfo = CommandLine.get_xinfo()
+    logger.info(f"Project directory: {xinfo.path}")
+    logger.info(f"xinfo written to: {params.xia2.settings.input.xinfo}")
+    logger.info(f"Parameters: {PhilIndex.get_diff().as_str()}")
+
+
+def run():
+    if len(sys.argv) < 2 or "-help" in sys.argv or "--help" in sys.argv:
+        help()
+        sys.exit()
+
+    if "-version" in sys.argv or "--version" in sys.argv:
+        print(xia2.XIA2Version.Version)
+        print(dials_version())
+        ccp4_version = get_ccp4_version()
+        if ccp4_version:
+            print("CCP4 %s" % ccp4_version)
+        sys.exit()
+
+    xia2.Handlers.Streams.setup_logging(logfile="xia2.txt", debugfile="xia2-debug.txt")
+
+    try:
+        check_environment()
+    except Exception as e:
+        traceback.print_exc(file=open("xia2-error.txt", "w"))
+        logger.debug(traceback.format_exc())
+        logger.error("Error setting up xia2 environment: %s" % str(e))
+        logger.warning(
+            "Please send the contents of xia2.txt, xia2-error.txt and xia2-debug.txt to:"
+        )
+        logger.warning("xia2.support@gmail.com")
+        sys.exit(1)
+
+    wd = os.getcwd()
+
+    try:
+        xia2_setup()
+    except Sorry as s:
+        logger.error("Error: %s", str(s))
+        sys.exit(1)
+    except Exception as e:
+        with open(os.path.join(wd, "xia2-error.txt"), "w") as fh:
+            traceback.print_exc(file=fh)
+        logger.debug(traceback.format_exc())
+        logger.error("Error: %s", str(e))
+        logger.warning(
+            "Please send the contents of xia2.txt, xia2-error.txt and xia2-debug.txt to:"
+        )
+        logger.warning("xia2.support@gmail.com")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Don't overwrite input kwarg in `load_imagesets`:

This meant that `load_imagesets` only returned one of the imagesets in cases that it should have returned multiple imagesets with the same template.

Also include subsequent bug fix for sorting sweeps with matching epochs, i.e. two sweeps with the same template will have the same epoch, resulting in a `TypeError: '<' not supported` error.

Fixes #498 