### PR TITLE
Parallelise I/O and computation of merging stats

### DIFF
--- a/Test/command_line/test_compare_merging_stats.py
+++ b/Test/command_line/test_compare_merging_stats.py
@@ -1,8 +1,5 @@
-import mock
 import os
 import pytest
-
-import iotbx.merging_statistics
 
 from xia2.command_line import compare_merging_stats
 
@@ -49,23 +46,16 @@ def test_compare_merging_stats_override_space_group(blend_mtz_files, run_in_tmpd
         assert os.path.exists(expected_file)
 
 
-def test_compare_merging_stats_d_min_d_max(blend_mtz_files, run_in_tmpdir, mocker):
-    spy = mocker.spy(iotbx.merging_statistics, "dataset_statistics")
-    compare_merging_stats.run(blend_mtz_files + ["d_min=2.5", "d_max=50"])
+def test_compare_merging_stats_d_min_d_max(blend_mtz_files, run_in_tmpdir):
+    results = compare_merging_stats.run(blend_mtz_files + ["d_min=2.5", "d_max=50"])
     for expected_file in expected_files:
         assert os.path.exists(expected_file)
-    spy.assert_called_with(
-        anomalous=False,
-        d_max=50.0,
-        d_min=2.5,
-        eliminate_sys_absent=False,
-        i_obs=mock.ANY,
-        n_bins=20,
-        use_internal_variance=False,
-    )
+    for result in results:
+        assert result.overall.d_min > 2.5
+        assert result.overall.d_max < 50
 
 
-def test_compare_merging_stats_small_multiples(dials_data, run_in_tmpdir, mocker):
+def test_compare_merging_stats_small_multiples(dials_data, run_in_tmpdir):
     data_dir = dials_data("blend_tutorial")
     blend_mtz_files = [
         data_dir.join("dataset_%03i.mtz" % (i + 1)).strpath for i in range(15)

--- a/command_line/compare_merging_stats.py
+++ b/command_line/compare_merging_stats.py
@@ -181,16 +181,17 @@ def plot_merging_stats(
         image_dir = "."
     elif not os.path.exists(image_dir):
         os.makedirs(image_dir)
-    for k in plots:
 
-        n_rows = 1
-        n_cols = 1
-        if small_multiples:
-            n_rows = int(math.floor(math.sqrt(len(results))))
-            n_cols = n_rows
-            while n_cols * n_rows < len(results):
-                n_cols += 1
-            assert n_cols * n_rows >= len(results), (n_cols, n_rows, len(results))
+    n_rows = 1
+    n_cols = 1
+    if small_multiples:
+        n_rows = int(math.floor(math.sqrt(len(results))))
+        n_cols = n_rows
+        while n_cols * n_rows < len(results):
+            n_cols += 1
+        assert n_cols * n_rows >= len(results), (n_cols, n_rows, len(results))
+
+    for k in plots:
 
         plot_data(
             results,

--- a/command_line/compare_merging_stats.py
+++ b/command_line/compare_merging_stats.py
@@ -97,6 +97,7 @@ def run(args):
         small_multiples=params.small_multiples,
         alpha=params.alpha,
     )
+    return results
 
 
 def get_merging_stats(

--- a/newsfragments/502.misc
+++ b/newsfragments/502.misc
@@ -1,0 +1,1 @@
+xia2.compare_merging_stats: parallelise computation of merging stats with multiple input files


### PR DESCRIPTION
Can give significant speedup when comparing many scaled_unmerged.mtz input files.

* Move static block out of loop
* Avoid using mocker.spy in test …