### PR TITLE
Reduce the number of scaling jobs in xia2.multiplex

### DIFF
--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -501,18 +501,10 @@ class MultiCrystalScale:
             data_manager = copy.deepcopy(self._data_manager)
             params = copy.deepcopy(self._params)
             params.unit_cell.refine = []
-            params.resolution.d_min = self._scaled.d_min
+            params.resolution.d_min = self._params.resolution.d_min
             scaled = Scale(data_manager, params, filtering=True)
             self.scale_and_filter_results = scaled.scale_and_filter_results
             logger.info("Scale and filtering:\n%s", self.scale_and_filter_results)
-            if self._params.resolution.d_min is None and len(
-                data_manager.experiments
-            ) < len(self._data_manager.experiments):
-                # Some data sets have been removed, perform full re-scaling on
-                # on the subset of experiments, including re-estimation of
-                # resolution limit
-                params.resolution.d_min = None
-                scaled = Scale(data_manager, params)
 
             data_manager.export_unmerged_mtz(
                 "filtered_unmerged.mtz", d_min=scaled.d_min

--- a/Modules/Report/__init__.py
+++ b/Modules/Report/__init__.py
@@ -71,6 +71,19 @@ class Report:
 
         self.params = params
 
+        if params.d_min or params.d_max:
+            intensities = intensities.resolution_filter(
+                d_min=params.d_min, d_max=params.d_max
+            )
+            if batches:
+                batches = batches.resolution_filter(
+                    d_min=params.d_min, d_max=params.d_max
+                )
+            if scales:
+                scales = scales.resolution_filter(
+                    d_min=params.d_min, d_max=params.d_max
+                )
+
         self.intensities = intensities
         self.experiments = experiments
         self.batches = batches


### PR DESCRIPTION
* Don't rescale after determination of resolution estimate, instead output truncated reflection file
* Use all reflections for deltacchalf analysis and cluster analysis, cutting out additional rounds of scaling.

New scaling workflow is something along these lines:
![multiplex_scaling_3](https://user-images.githubusercontent.com/2810624/88795025-44a2ac80-d197-11ea-922c-a156a2bb4c16.png)

Goes some way towards resolving #486 