### PR TITLE
Useful error mesage if passed foo_000001.h5

### DIFF
--- a/Applications/xia2_main.py
+++ b/Applications/xia2_main.py
@@ -1,6 +1,6 @@
 # A top-level interface to the whole of xia2, for data processing & analysis.
 
-
+import glob
 import logging
 import math
 import os
@@ -78,7 +78,21 @@ def check_hdf5_master_files(master_files):
                 bad.append(filename)
 
     if bad:
-        sys.exit("Not master files: %s" % " ".join(bad))
+
+        dirs = set([os.path.split(b)[0] for b in bad])
+        masters = sum((glob.glob(os.path.join(d, "*_master.h5")) for d in dirs), [])
+        nxss = sum((glob.glob(os.path.join(d, "*.nxs")) for d in dirs), [])
+
+        message = (
+            "Provided input files not master files:\n  "
+            + "\n  ".join(bad)
+            + "\ndo you mean one of:\n  "
+            + "\n  ".join(masters)
+            + "\nor:\n  "
+            + "\n  ".join(nxss)
+        )
+
+        sys.exit(message)
 
 
 def get_command_line():

--- a/Applications/xia2_main.py
+++ b/Applications/xia2_main.py
@@ -78,8 +78,7 @@ def check_hdf5_master_files(master_files):
                 bad.append(filename)
 
     if bad:
-        filenames = " ".join(bad)
-        sys.exit(f"Not master files: {filenames}")
+        sys.exit("Not master files: %s" % " ".join(bad))
 
 
 def get_command_line():

--- a/Applications/xia2_main.py
+++ b/Applications/xia2_main.py
@@ -1,6 +1,7 @@
 # A top-level interface to the whole of xia2, for data processing & analysis.
 
 import glob
+import itertools
 import logging
 import math
 import os
@@ -80,16 +81,18 @@ def check_hdf5_master_files(master_files):
     if bad:
 
         dirs = set([os.path.split(b)[0] for b in bad])
-        masters = sum((glob.glob(os.path.join(d, "*_master.h5")) for d in dirs), [])
-        nxss = sum((glob.glob(os.path.join(d, "*.nxs")) for d in dirs), [])
+        masters = itertools.chain.from_iterable(
+            glob.glob(os.path.join(d, "*_master.h5")) for d in dirs
+        )
+        nxss = itertools.chain.from_iterable(
+            glob.glob(os.path.join(d, "*.nxs")) for d in dirs
+        )
 
         message = (
             "Provided input files not master files:\n  "
             + "\n  ".join(bad)
             + "\ndo you mean one of:\n  "
-            + "\n  ".join(masters)
-            + "\nor:\n  "
-            + "\n  ".join(nxss)
+            + "\n  ".join(itertools.chain.from_iterable((masters, nxss)))
         )
 
         sys.exit(message)

--- a/Applications/xia2_main.py
+++ b/Applications/xia2_main.py
@@ -80,7 +80,7 @@ def check_hdf5_master_files(master_files):
 
     if bad:
 
-        dirs = set([os.path.split(b)[0] for b in bad])
+        dirs = set(os.path.split(b)[0] for b in bad)
         masters = itertools.chain.from_iterable(
             glob.glob(os.path.join(d, "*_master.h5")) for d in dirs
         )

--- a/Applications/xia2_main.py
+++ b/Applications/xia2_main.py
@@ -74,9 +74,12 @@ def check_hdf5_master_files(master_files):
     bad = []
 
     for filename in master_files:
-        with h5py.File(filename, "r") as f:
-            if b"/data" in f and b"/entry" not in f:
-                bad.append(filename)
+        try:
+            with h5py.File(filename, "r") as f:
+                if b"/data" in f and b"/entry" not in f:
+                    bad.append(filename)
+        except OSError:
+            bad.append(filename)
 
     if bad:
 

--- a/Test/Applications/test_check_hdf5_master_files.py
+++ b/Test/Applications/test_check_hdf5_master_files.py
@@ -1,0 +1,14 @@
+import pytest
+
+from xia2.Applications.xia2_main import check_hdf5_master_files
+
+
+def test_check_hdf5_master_files(dials_data):
+
+    master = dials_data("vmxi_thaumatin").join("image_15799_master.h5").strpath
+    data = dials_data("vmxi_thaumatin").join("image_15799_data_000001.h5").strpath
+
+    with pytest.raises(SystemExit):
+        check_hdf5_master_files([data])
+
+    check_hdf5_master_files([master])

--- a/newsfragments/509.feature
+++ b/newsfragments/509.feature
@@ -1,4 +1,4 @@
-Report more useful error message if given Eiger data file not master file, including suggestions of possible master files in the same directory e.g.
+Report more useful error message if given an Eiger data file rather than a master file, including suggestions of possible master files in the same directory e.g.
 
 ::
 

--- a/newsfragments/509.feature
+++ b/newsfragments/509.feature
@@ -1,0 +1,1 @@
+HDF5 file input: if data_000001.h5 passed not master give useful error message. 

--- a/newsfragments/509.feature
+++ b/newsfragments/509.feature
@@ -8,6 +8,5 @@ Report more useful error message if given an Eiger data file rather than a maste
   do you mean one of:
     /Users/graeme/data/i04-eiger-small/Therm_6_1_master.h5
     /Users/graeme/data/i04-eiger-small/Therm_6_2_master.h5
-  or:
     /Users/graeme/data/i04-eiger-small/Therm_6_2.nxs
     /Users/graeme/data/i04-eiger-small/Therm_6_1.nxs

--- a/newsfragments/509.feature
+++ b/newsfragments/509.feature
@@ -1,1 +1,13 @@
-HDF5 file input: if data_000001.h5 passed not master give useful error message. 
+Report more useful error message if given Eiger data file not master file, including suggestions of possible master files in the same directory e.g.
+
+::
+
+  Command line: xia2 image=/Users/graeme/data/i04-eiger-small/Therm_6_2_000001.h5
+  Provided input files not master files:
+    /Users/graeme/data/i04-eiger-small/Therm_6_2_000001.h5
+  do you mean one of:
+    /Users/graeme/data/i04-eiger-small/Therm_6_1_master.h5
+    /Users/graeme/data/i04-eiger-small/Therm_6_2_master.h5
+  or:
+    /Users/graeme/data/i04-eiger-small/Therm_6_2.nxs
+    /Users/graeme/data/i04-eiger-small/Therm_6_1.nxs


### PR DESCRIPTION
Check the input master files for:

 - presence of /entry
 - absence of /data

if any of the input files fail both tests then append to a bad file list, `sys.exit` if this list not empty with helpful message. Fixes #508.