### PR TITLE
Enable Python 3.8 support for xia2

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,8 +13,8 @@ jobs:
         PYTHON_VERSION: 3.6
       python37:
         PYTHON_VERSION: 3.7
-#     python38:
-#       PYTHON_VERSION: 3.8
+      python38:
+        PYTHON_VERSION: 3.8
   timeoutInMinutes: 150
 
   steps:

--- a/.azure-pipelines/azure-pipelines-mac.yml
+++ b/.azure-pipelines/azure-pipelines-mac.yml
@@ -13,8 +13,8 @@ jobs:
         PYTHON_VERSION: 3.6
       python37:
         PYTHON_VERSION: 3.7
-#      python38:
-#        PYTHON_VERSION: 3.8
+      python38:
+        PYTHON_VERSION: 3.8
   timeoutInMinutes: 150
 
   steps:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,4 +13,4 @@ comment:
   layout: "diff, flags"
   branches:
     - master
-  after_n_builds: 3
+  after_n_builds: 4

--- a/command_line/xia2_html.py
+++ b/command_line/xia2_html.py
@@ -1,3 +1,5 @@
+# LIBTBX_SET_DISPATCHER_NAME xia2.html
+
 import cgi
 import glob
 import json

--- a/command_line/xia2_main.py
+++ b/command_line/xia2_main.py
@@ -280,7 +280,7 @@ def xia2_main(stop_after=None):
 
             # looks like this import overwrites the initial command line
             # Phil overrides so... for https://github.com/xia2/xia2/issues/150
-            from xia2.command_line.html import generate_xia2_html
+            from xia2.command_line.xia2_html import generate_xia2_html
 
             if params.xia2.settings.small_molecule:
                 params.xia2.settings.report.xtriage_analysis = False

--- a/newsfragments/510.feature
+++ b/newsfragments/510.feature
@@ -1,0 +1,1 @@
+xia2 now support Python 3.8


### PR DESCRIPTION
* build & test xia2 on Azure + Python 3.8
* rename `xia2/command_line/html.py` to `xia2/command_line/xia2_html.py` and update references to avoid import bug reported in dials/dials#1356

Fixes dials/dials#1356