### PR TITLE
Run test in a temp dir to avoid PHIL droppings

### DIFF
--- a/Test/Schema/test_Schema.py
+++ b/Test/Schema/test_Schema.py
@@ -53,7 +53,7 @@ def test_load_imageset_template_missing_images(insulin_with_missing_image):
         assert imagesets[0].get_array_range() == (0, 22)
 
 
-def test_load_imageset_split_sweep(dials_data):
+def test_load_imageset_split_sweep(dials_data, run_in_tmpdir):
     directory = dials_data("insulin")
     with mock.patch.object(
         sys,

--- a/newsfragments/514.misc
+++ b/newsfragments/514.misc
@@ -1,0 +1,2 @@
+Make sure a test that produces output files is run in a temporary directory.
+The test is ``xia2.Test.Schema.test_Schema.test_load_imageset_split_sweep``.


### PR DESCRIPTION
This test creates the files xia2-diff.phil and xia2-working.phil.