### PR TITLE
set_batch_offset() on imageset version of scan

### DIFF
--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -207,6 +207,8 @@ class DataManager:
 
         for i, expt in enumerate(self._experiments):
             expt.scan.set_batch_offset(i * 10 ** n)
+            # This may be a different scan instance ¯\_(ツ)_/¯
+            expt.imageset.get_scan().set_batch_offset(expt.scan.get_batch_offset())
             logger.debug(
                 f"{expt.scan.get_batch_offset()} {expt.scan.get_batch_range()}"
             )

--- a/newsfragments/518.bugfix
+++ b/newsfragments/518.bugfix
@@ -1,0 +1,1 @@
+xia2.multiplex: fix for dose parameter when scan doesn't start at 1


### PR DESCRIPTION
Apparently `expt.imageset.get_scan()` is a different scan instance to `expt.scan`. As highlighted by dials/dials#1383 it is necessary to ensure that both scan objects have the same batch_offset.