### PR TITLE
Update black to 20.8b1 and clean clutter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black
-  rev: 19.10b0
+  rev: 20.8b1
   hooks:
   - id: black
     args: [--safe, --quiet]

--- a/Driver/timing.py
+++ b/Driver/timing.py
@@ -130,11 +130,13 @@ def visualise_db(timing_db):
             not ordered_by_start or ordered_by_end[0][0] < ordered_by_start[0][0]
         ):
             timestamp, finishing_task = ordered_by_end.pop(0)
-            output_line = "{timestamp:{time_width}.1f}s  {nothing:{index_width}} ".format(
-                nothing="",
-                index_width=index_width,
-                time_width=time_width,
-                timestamp=timestamp - relative_start_time,
+            output_line = (
+                "{timestamp:{time_width}.1f}s  {nothing:{index_width}} ".format(
+                    nothing="",
+                    index_width=index_width,
+                    time_width=time_width,
+                    timestamp=timestamp - relative_start_time,
+                )
             )
             for n, task in enumerate(running_tasks):
                 if task is None:

--- a/Modules/DeltaCcHalf.py
+++ b/Modules/DeltaCcHalf.py
@@ -46,8 +46,10 @@ class DeltaCcHalf:
                     ma, assert_is_similar_symmetry=False
                 ).set_observation_type(unmerged_intensities.observation_type())
 
-        self.binner = unmerged_intensities.eliminate_sys_absent().setup_binner_counting_sorted(
-            n_bins=self._n_bins
+        self.binner = (
+            unmerged_intensities.eliminate_sys_absent().setup_binner_counting_sorted(
+                n_bins=self._n_bins
+            )
         )
         self.cc_half_overall = self._compute_mean_weighted_cc_half(unmerged_intensities)
 
@@ -99,7 +101,10 @@ class DeltaCcHalf:
 
             ccs.append(self._compute_mean_weighted_cc_half(unmerged_i))
             logger.debug(
-                "CC½ excluding batches %i-%i: %.3f", group_start, group_end, ccs[-1],
+                "CC½ excluding batches %i-%i: %.3f",
+                group_start,
+                group_end,
+                ccs[-1],
             )
         return ccs
 
@@ -113,7 +118,8 @@ class DeltaCcHalf:
             cc_bins = intensities.cc_one_half(use_binning=True, return_n_refl=True)
         bin_data = [b for b in cc_bins.data if b is not None]
         return flex.mean_weighted(
-            flex.double(b[0] for b in bin_data), flex.double(b[1] for b in bin_data),
+            flex.double(b[0] for b in bin_data),
+            flex.double(b[1] for b in bin_data),
         )
 
     def _compute_normalised_delta_ccs(self):

--- a/Modules/Integrater/DialsIntegrater.py
+++ b/Modules/Integrater/DialsIntegrater.py
@@ -261,7 +261,8 @@ class DialsIntegrater(Integrater):
         pname, xname, dname = self.get_integrater_project_info()
         sweep = self.get_integrater_sweep_name()
         FileHandler.record_log_file(
-            f"{pname} {xname} {dname} {sweep} INTEGRATE", integrate.get_log_file(),
+            f"{pname} {xname} {dname} {sweep} INTEGRATE",
+            integrate.get_log_file(),
         )
 
         integrate.run()
@@ -431,10 +432,12 @@ class DialsIntegrater(Integrater):
             pname, xname, dname = self.get_integrater_project_info()
             sweep = self.get_integrater_sweep_name()
             FileHandler.record_more_data_file(
-                f"{pname} {xname} {dname} {sweep}", self.get_integrated_experiments(),
+                f"{pname} {xname} {dname} {sweep}",
+                self.get_integrated_experiments(),
             )
             FileHandler.record_more_data_file(
-                f"{pname} {xname} {dname} {sweep}", self.get_integrated_reflections(),
+                f"{pname} {xname} {dname} {sweep}",
+                self.get_integrated_reflections(),
             )
 
             return hklout
@@ -502,10 +505,12 @@ class DialsIntegrater(Integrater):
             pname, xname, dname = self.get_integrater_project_info()
             sweep = self.get_integrater_sweep_name()
             FileHandler.record_more_data_file(
-                f"{pname} {xname} {dname} {sweep}", self.get_integrated_experiments(),
+                f"{pname} {xname} {dname} {sweep}",
+                self.get_integrated_experiments(),
             )
             FileHandler.record_more_data_file(
-                f"{pname} {xname} {dname} {sweep}", self.get_integrated_reflections(),
+                f"{pname} {xname} {dname} {sweep}",
+                self.get_integrated_reflections(),
             )
             return None  # this will be set to intgr_hklout - better to cause failure
             # due to it being none than it be set wrong and not knowing?

--- a/Modules/Scaler/CommonScaler.py
+++ b/Modules/Scaler/CommonScaler.py
@@ -160,7 +160,8 @@ class CommonScaler(Scaler):
                 p = self._factory.Pointless()
 
             FileHandler.record_log_file(
-                f"{self._scalr_pname} {self._scalr_xname} pointless", p.get_log_file(),
+                f"{self._scalr_pname} {self._scalr_xname} pointless",
+                p.get_log_file(),
             )
 
             if len(self._sweep_handler.get_epochs()) > 1:

--- a/Modules/Scaler/DialsScaler.py
+++ b/Modules/Scaler/DialsScaler.py
@@ -596,7 +596,8 @@ pipeline=dials (supported for pipeline=dials-aimless).
         )
         self._scaler.scale()
         FileHandler.record_html_file(
-            f"{self._scalr_pname} {self._scalr_xname} SCALE", self._scaler.get_html(),
+            f"{self._scalr_pname} {self._scalr_xname} SCALE",
+            self._scaler.get_html(),
         )
         self._scaled_experiments = self._scaler.get_scaled_experiments()
         self._scaled_reflections = self._scaler.get_scaled_reflections()
@@ -645,10 +646,12 @@ pipeline=dials (supported for pipeline=dials-aimless).
             self._scalr_likely_spacegroups = [sg.type().lookup_symbol()]
 
         FileHandler.record_more_data_file(
-            f"{self._scalr_pname} {self._scalr_xname} scaled", self._scaled_experiments,
+            f"{self._scalr_pname} {self._scalr_xname} scaled",
+            self._scaled_experiments,
         )
         FileHandler.record_more_data_file(
-            f"{self._scalr_pname} {self._scalr_xname} scaled", self._scaled_reflections,
+            f"{self._scalr_pname} {self._scalr_xname} scaled",
+            self._scaled_reflections,
         )
 
         # Run twotheta refine

--- a/Test/regression/test_X4_wide.py
+++ b/Test/regression/test_X4_wide.py
@@ -45,10 +45,14 @@ def test_incompatible_pipeline_scaler(pipeline, scaler, tmpdir, ccp4):
     command_line = ["xia2", "pipeline=%s" % pipeline, "nproc=1", "scaler=%s" % scaler]
     result = procrunner.run(command_line, working_directory=tmpdir)
     assert result.returncode
-    assert "Error: scaler=%s not compatible with pipeline=%s" % (
-        scaler,
-        pipeline,
-    ) in result.stdout.decode("latin-1")
+    assert (
+        "Error: scaler=%s not compatible with pipeline=%s"
+        % (
+            scaler,
+            pipeline,
+        )
+        in result.stdout.decode("latin-1")
+    )
 
 
 def test_dials_aimless(regression_test, dials_data, tmpdir, ccp4):
@@ -126,7 +130,10 @@ def test_dials(regression_test, dials_data, tmpdir, ccp4):
         result,
         tmpdir,
         ccp4,
-        expected_data_files=["foo_bar_scaled.mtz", "foo_bar_scaled_unmerged.mtz",],
+        expected_data_files=[
+            "foo_bar_scaled.mtz",
+            "foo_bar_scaled_unmerged.mtz",
+        ],
         expected_space_group="P41212",
     )
     assert success, issues

--- a/Test/regression/test_multiplex.py
+++ b/Test/regression/test_multiplex.py
@@ -72,7 +72,8 @@ def test_proteinase_k(mocker, regression_test, dials_data, tmpdir):
 
 
 @pytest.mark.parametrize(
-    "d_min", [None, 2.0],
+    "d_min",
+    [None, 2.0],
 )
 def test_proteinase_k_filter_deltacchalf(d_min, regression_test, dials_data, tmpdir):
     data_dir = dials_data("multi_crystal_proteinase_k")

--- a/Wrappers/Dials/Scale.py
+++ b/Wrappers/Dials/Scale.py
@@ -431,8 +431,8 @@ def DialsScale(DriverType=None, decay_correction=None):
                 with open(scale_and_filter_filename) as fh:
                     from dials.algorithms.scaling import scale_and_filter
 
-                    self._scale_and_filter_results = scale_and_filter.AnalysisResults.from_dict(
-                        json.load(fh)
+                    self._scale_and_filter_results = (
+                        scale_and_filter.AnalysisResults.from_dict(json.load(fh))
                     )
 
             return "OK"

--- a/Wrappers/XDS/XDSIdxref.py
+++ b/Wrappers/XDS/XDSIdxref.py
@@ -460,9 +460,11 @@ def XDSIdxref(DriverType=None, params=None):
             # one, if self._symm is set...
 
             if self._symm:
-                assert self._indexing_solutions, (
-                    "No remaining indexing solutions (%s, %s)"
-                    % (s2l(self._symm), self._symm)
+                assert (
+                    self._indexing_solutions
+                ), "No remaining indexing solutions (%s, %s)" % (
+                    s2l(self._symm),
+                    self._symm,
                 )
             else:
                 assert self._indexing_solutions, "No remaining indexing solutions"

--- a/command_line/compare_merging_stats.py
+++ b/command_line/compare_merging_stats.py
@@ -271,7 +271,12 @@ def plot_data(
                         ]
                         y = [getattr(b, k) for b in res.bins]
                         ax.plot(
-                            x, y, linestyle="-", color="grey", linewidth=1, alpha=alpha,
+                            x,
+                            y,
+                            linestyle="-",
+                            color="grey",
+                            linewidth=1,
+                            alpha=alpha,
                         )
         else:
             ax = plt.gca()

--- a/command_line/to_shelxcde.py
+++ b/command_line/to_shelxcde.py
@@ -150,7 +150,11 @@ def write_shelxc_script(hkl_files, params):
                     "spag %s" % sg,
                 ]
                 + datasets
-                + ["maxm %d" % params["maxm"], "eof", "",]
+                + [
+                    "maxm %d" % params["maxm"],
+                    "eof",
+                    "",
+                ]
             )
         )
 

--- a/command_line/xia2_html.py
+++ b/command_line/xia2_html.py
@@ -488,7 +488,7 @@ def extract_loggraph_tables(logfile):
     return data_plots.import_ccp4i_logfile(file_name=logfile)
 
 
-def table_to_c3js_charts(table,):
+def table_to_c3js_charts(table):
     html_graphs = {}
     draw_chart_template = """
 var chart_%(name)s = c3.generate({


### PR DESCRIPTION
Since the automatic job has failed for the last few weeks, here's a manual run with the new black changes.

I manually tweaked one bad-split where it treated a single argument function with a trailing comma as something that should be split.