### PR TITLE
Multiplex select_on_experiment_identifiers bug fix

### DIFF
--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -399,10 +399,10 @@ class MultiCrystalScale:
         )
         keep_expts = []
         for i, expt in enumerate(self._data_manager.experiments):
+            refl_used = reflections.select(used_in_refinement_mask)
             if (
-                reflections.select(used_in_refinement_mask)
-                .select_on_experiment_identifiers([expt.identifier])
-                .size()
+                expt.identifier in refl_used.experiment_identifiers().values()
+                and refl_used.select_on_experiment_identifiers([expt.identifier]).size()
             ):
                 keep_expts.append(expt.identifier)
             else:

--- a/newsfragments/524.bugfix
+++ b/newsfragments/524.bugfix
@@ -1,0 +1,1 @@
+xia2.multiplex: bug fix for corner case where reflections are present but none were used_in_refinement, leading to an error in reflections.select_on_experiment_identifiers()


### PR DESCRIPTION
Fix for corner case where reflections are present but none were used_in_refinement, leading to an error in select_on_experiment_identifiers.