### PR TITLE
Multiplex filter_dose bug fix

### DIFF
--- a/newsfragments/525.bugfix
+++ b/newsfragments/525.bugfix
@@ -1,0 +1,1 @@
+xia2.multiplex: bug fix if one or more experiment has an image range that doesn't overlap with the requested dose range. Instead, remove this experiment from further analysis.


### PR DESCRIPTION
If one or more experiments have an image_range that does not overlap
with the requested dose range this resulted in an error in
slice_experiments. Instead, remove an experiment if its image_range
is outside of the dose range.

Add a test for DataManager.filter_dose().