### PR TITLE
Expose scaling refl selection method

### DIFF
--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -69,14 +69,29 @@ scaling
     .type = choice
   outlier_rejection = simple *standard
     .type = choice
-  Isigma_range = 2.0,100000
-    .type = floats(size=2)
   min_partiality = None
     .type = float(value_min=0, value_max=1)
   partiality_cutoff = None
     .type = float(value_min=0, value_max=1)
+  reflection_selection {
+    method = quasi_random intensity_ranges use_all random
+      .type = choice
+      .help = "Method to use when choosing a reflection subset for scaling model"
+              "minimisation."
+              "The quasi_random option randomly selects reflections groups"
+              "within a dataset, and also selects groups which have good"
+              "connectedness across datasets for multi-dataset cases. The random"
+              "option selects reflection groups randomly for both single"
+              "and multi dataset scaling, so for a single dataset"
+              "quasi_random == random."
+              "The intensity_ranges option uses the E2_range, Isigma_range and"
+              "d_range options to the subset of reflections"
+              "The use_all option uses all suitable reflections, which may be"
+              "slow for large datasets."
+    Isigma_range = 2.0,100000
+      .type = floats(size=2)
+  }
 }
-
 symmetry {
   resolve_indexing_ambiguity = True
     .type = bool
@@ -1040,12 +1055,18 @@ class Scale:
             scaler.set_bfactor(brotation=decay_interval)
 
         scaler.set_resolution(d_min=d_min, d_max=d_max)
-        if self._params.scaling.Isigma_range is not None:
-            scaler.set_isigma_selection(self._params.scaling.Isigma_range)
+        if self._params.scaling.reflection_selection.Isigma_range is not None:
+            scaler.set_isigma_selection(
+                self._params.scaling.reflection_selection.Isigma_range
+            )
         if self._params.scaling.min_partiality is not None:
             scaler.set_min_partiality(self._params.scaling.min_partiality)
         if self._params.scaling.partiality_cutoff is not None:
             scaler.set_partiality_cutoff(self._params.scaling.partiality_cutoff)
+        if self._params.scaling.reflection_selection.method is not None:
+            scaler.set_reflection_selection_method(
+                self._params.scaling.reflection_selection.method
+            )
 
         scaler.set_full_matrix(False)
 

--- a/Wrappers/Dials/Scale.py
+++ b/Wrappers/Dials/Scale.py
@@ -83,6 +83,7 @@ def DialsScale(DriverType=None, decay_correction=None):
             self._n_absorption_bins = None
 
             self._isigma_selection = None
+            self._reflection_selection_method = None
 
             self._intensities = None
 
@@ -184,6 +185,9 @@ def DialsScale(DriverType=None, decay_correction=None):
         def set_isigma_selection(self, isigma_selection):
             assert len(isigma_selection) == 2
             self._isigma_selection = isigma_selection
+
+        def set_reflection_selection_method(self, reflection_selection_method):
+            self._reflection_selection_method = reflection_selection_method
 
         def set_error_model(self, error_model="basic"):
             self._error_model = error_model
@@ -330,6 +334,11 @@ def DialsScale(DriverType=None, decay_correction=None):
                 self.add_command_line(
                     "reflection_selection.Isigma_range=%f,%f"
                     % tuple(self._isigma_selection)
+                )
+
+            if self._reflection_selection_method is not None:
+                self.add_command_line(
+                    f"reflection_selection.method={self._reflection_selection_method}"
                 )
 
             if self._d_min is not None:

--- a/newsfragments/529.feature
+++ b/newsfragments/529.feature
@@ -1,0 +1,1 @@
+xia2.multiplex: Allow the user to override the default dials.scale reflection_selection.method parameter


### PR DESCRIPTION
For narrow wedges, the default `dials.scale` option of `reflection_selection.method=quasi_random` can occassionally fail. Setting it to `reflection_selection.method=use_all` can work around this error. This PR exposes the parameter through xia2.multiplex.
Move the `Isigma_range` parameter inside the new `reflection_selection` phil scope.