### PR TITLE
multiplex: use dials.scale default Isigma_range

### DIFF
--- a/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/Modules/MultiCrystal/ScaleAndMerge.py
@@ -88,7 +88,7 @@ scaling
               "d_range options to the subset of reflections"
               "The use_all option uses all suitable reflections, which may be"
               "slow for large datasets."
-    Isigma_range = 2.0,100000
+    Isigma_range = None
       .type = floats(size=2)
   }
 }

--- a/newsfragments/535.misc
+++ b/newsfragments/535.misc
@@ -1,0 +1,1 @@
+xia2.multiplex: use default dials.scale Isigma_range unless explicitly overridden


### PR DESCRIPTION
Overriding the dials.scale default can cause some issues in conjunction 
with `reflection_selection.method=quasi_random` for particularly narrow
wedges:
https://github.com/xia2/xia2/pull/529#issuecomment-721098937