### PR TITLE
drop xia2 mock dependency

### DIFF
--- a/Handlers/test_CommandLine.py
+++ b/Handlers/test_CommandLine.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import sys
 

--- a/Test/Modules/Indexer/test_DIALS_indexer.py
+++ b/Test/Modules/Indexer/test_DIALS_indexer.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Indexer/test_XDS_indexer.py
+++ b/Test/Modules/Indexer/test_XDS_indexer.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Indexer/test_XDS_indexer_II.py
+++ b/Test/Modules/Indexer/test_XDS_indexer_II.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Integrater/test_DialsIntegrater.py
+++ b/Test/Modules/Integrater/test_DialsIntegrater.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Integrater/test_XDSIntegrater.py
+++ b/Test/Modules/Integrater/test_XDSIntegrater.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Scaler/test_CCP4ScalerA.py
+++ b/Test/Modules/Scaler/test_CCP4ScalerA.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-import mock
+from unittest import mock
 import pathlib
 import pytest
 

--- a/Test/Modules/Scaler/test_XDSScalerA.py
+++ b/Test/Modules/Scaler/test_XDSScalerA.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-import mock
+from unittest import mock
 import pathlib
 import pytest
 

--- a/Test/Schema/test_XProject.py
+++ b/Test/Schema/test_XProject.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-import mock
+from unittest import mock
 import pathlib
 
 

--- a/Test/Wrappers/Dials/test_dials_wrappers.py
+++ b/Test/Wrappers/Dials/test_dials_wrappers.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import shutil

--- a/libtbx_config
+++ b/libtbx_config
@@ -5,7 +5,6 @@
     "python_required": [
         "dials-data>=2.0",
         "Jinja2",
-        "mock>=2.0",
         "procrunner",
         "pytest>=3.1",
         "pytest-mock>=1.11,<2",

--- a/newsfragments/540.misc
+++ b/newsfragments/540.misc
@@ -1,0 +1,1 @@
+xia2 tests now use unittest.mock instead of mock


### PR DESCRIPTION
and use the standard library implementation (`unittest.mock`) instead of the `mock` package.

This is independent of the `pytest-mock` PRs going around in parallel