### PR TITLE
update tests for mock, pytest-mock and procrunner

### DIFF
--- a/Handlers/test_CommandLine.py
+++ b/Handlers/test_CommandLine.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import sys
 

--- a/Test/Modules/Indexer/test_DIALS_indexer.py
+++ b/Test/Modules/Indexer/test_DIALS_indexer.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Indexer/test_XDS_indexer.py
+++ b/Test/Modules/Indexer/test_XDS_indexer.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Indexer/test_XDS_indexer_II.py
+++ b/Test/Modules/Indexer/test_XDS_indexer_II.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Integrater/test_DialsIntegrater.py
+++ b/Test/Modules/Integrater/test_DialsIntegrater.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Integrater/test_XDSIntegrater.py
+++ b/Test/Modules/Integrater/test_XDSIntegrater.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/Test/Modules/Scaler/test_CCP4ScalerA.py
+++ b/Test/Modules/Scaler/test_CCP4ScalerA.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-import mock
+from unittest import mock
 import pathlib
 import pytest
 

--- a/Test/Modules/Scaler/test_XDSScalerA.py
+++ b/Test/Modules/Scaler/test_XDSScalerA.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-import mock
+from unittest import mock
 import pathlib
 import pytest
 

--- a/Test/Schema/test_XProject.py
+++ b/Test/Schema/test_XProject.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-import mock
+from unittest import mock
 import pathlib
 
 

--- a/Test/Wrappers/Dials/test_dials_wrappers.py
+++ b/Test/Wrappers/Dials/test_dials_wrappers.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 import shutil

--- a/Test/regression/test_delta_cc_half.py
+++ b/Test/regression/test_delta_cc_half.py
@@ -1,5 +1,6 @@
 from xia2.command_line.delta_cc_half import run
 from xia2.Modules.DeltaCcHalf import DeltaCcHalf
+import pytest_mock
 
 
 def test_from_experiments_reflections(dials_data, tmpdir, capsys, mocker):
@@ -9,7 +10,11 @@ def test_from_experiments_reflections(dials_data, tmpdir, capsys, mocker):
     mocker.spy(DeltaCcHalf, "get_table")
     with tmpdir.as_cwd():
         run(input_files)
-        assert DeltaCcHalf.get_table.return_value == [
+        if getattr(pytest_mock, "version", "").startswith("1."):
+            rv = DeltaCcHalf.get_table.return_value
+        else:
+            rv = DeltaCcHalf.get_table.spy_return
+        assert rv == [
             ["Dataset", "Batches", "CC½", "ΔCC½", "σ"],
             ["0", "8 to 1795", " 0.995", " 0.000", "-1.11"],
             ["3", "5 to 1694", " 0.995", " 0.000", "-0.59"],
@@ -30,7 +35,11 @@ def test_image_groups_from_unmerged_mtz(dials_data, tmpdir, capsys, mocker):
                 "group_size=10",
             ]
         )
-        assert DeltaCcHalf.get_table.return_value == [
+        if getattr(pytest_mock, "version", "").startswith("1."):
+            rv = DeltaCcHalf.get_table.return_value
+        else:
+            rv = DeltaCcHalf.get_table.spy_return
+        assert rv == [
             ["Dataset", "Batches", "CC½", "ΔCC½", "σ"],
             ["0", "11 to 20", " 0.922", " 0.007", "-0.95"],
             ["0", "31 to 40", " 0.922", " 0.007", "-0.84"],

--- a/Test/regression/test_multiple_sweeps.py
+++ b/Test/regression/test_multiple_sweeps.py
@@ -49,4 +49,4 @@ def test_multiple_sweeps(multi_sweep_type, ccp4, dials_data, run_in_tmpdir):
     ]
     result = procrunner.run(command + [f"image={image}" for image in images])
 
-    assert not result["exitcode"] and not result["timeout"]
+    assert not result.returncode

--- a/Test/regression/test_multiplex.py
+++ b/Test/regression/test_multiplex.py
@@ -17,6 +17,8 @@ from xia2.Modules.Report import Report
 from xia2.command_line.multiplex import run as run_multiplex
 from xia2.Modules.MultiCrystal import ScaleAndMerge
 
+import pytest_mock
+
 
 expected_data_files = [
     "scaled.expt",
@@ -43,7 +45,12 @@ def test_proteinase_k(mocker, regression_test, dials_data, tmpdir):
         "completeness_vs_dose",
         "rd_vs_batch_difference",
     ):
-        assert Report.pychef_plots.return_value[k]["data"][0]["x"] == list(range(26))
+        if getattr(pytest_mock, "version", "").startswith("1."):
+            assert Report.pychef_plots.return_value[k]["data"][0]["x"] == list(
+                range(26)
+            )
+        else:
+            assert Report.pychef_plots.spy_return[k]["data"][0]["x"] == list(range(26))
     for f in expected_data_files:
         assert tmpdir.join(f).check(file=1), "expected file %s missing" % f
     multiplex_expts = load.experiment_list(

--- a/libtbx_config
+++ b/libtbx_config
@@ -5,7 +5,6 @@
     "python_required": [
         "dials-data>=2.0",
         "Jinja2",
-        "mock>=2.0",
         "procrunner",
         "pytest>=3.1",
         "pytest-mock",

--- a/libtbx_config
+++ b/libtbx_config
@@ -8,7 +8,7 @@
         "mock>=2.0",
         "procrunner",
         "pytest>=3.1",
-        "pytest-mock>=1.11,<2",
+        "pytest-mock",
         "tabulate",
     ],
 }

--- a/newsfragments/541.misc
+++ b/newsfragments/541.misc
@@ -1,0 +1,1 @@
+Support pytest-mock versions >1, drop dependency on mock package


### PR DESCRIPTION
* drop dependency on package `mock` and use the standard library implementation instead
* allow running with newer versions of `pytest-mock` (unblocking dials/dials#1498)
* fix deprecation warnings with current `procrunner` versions