### PR TITLE
Add dano/sigdano by resolution plot to xia2.html

### DIFF
--- a/newsfragments/551.feature
+++ b/newsfragments/551.feature
@@ -1,1 +1,1 @@
-xia2.html: Add dano/sigdano by resolution plot if running xia2 with anomalous=True
+``xia2.html``: Add dano/sigdano by resolution plot if running xia2 with ``anomalous=True``

--- a/newsfragments/551.feature
+++ b/newsfragments/551.feature
@@ -1,0 +1,1 @@
+xia2.html: Add dano/sigdano by resolution plot if running xia2 with anomalous=True

--- a/newsfragments/551.feature
+++ b/newsfragments/551.feature
@@ -1,1 +1,1 @@
-``xia2.html``: Add dano/sigdano by resolution plot if running xia2 with ``anomalous=True``
+``xia2.html``: Add <dF/s(dF)> by resolution plot if running xia2 with ``anomalous=True``

--- a/src/xia2/Wrappers/Dials/Merge.py
+++ b/src/xia2/Wrappers/Dials/Merge.py
@@ -26,6 +26,7 @@ def DialsMerge(DriverType=None):
             self._reflections_filename = None
             self._mtz_filename = None
             self._truncate = False
+            self._html_report = None
             self._project_name = None
             self._crystal_names = None
             self._dataset_names = None
@@ -61,6 +62,9 @@ def DialsMerge(DriverType=None):
         def get_mtz_filename(self):
             return self._mtz_filename
 
+        def set_html_report(self, filename):
+            self._html_report = filename
+
         def run(self):
             """Run dials.merge"""
             self.clear_command_line()
@@ -85,6 +89,7 @@ def DialsMerge(DriverType=None):
                 self.add_command_line(
                     "partiality_threshold=%s" % self._partiality_threshold
                 )
+            self.add_command_line("output.html=%s" % self._html_report)
 
             self.start()
             self.close_wait()


### PR DESCRIPTION
This is the xia2 counterpart to https://github.com/dials/dials/pull/1483

If anomalous=True, this adds the dano/sigdano plot to each 'Dataset X' tab in the analysis by resolution section.

This will fail the tests until the DIALS PR is merged.

The `dials.merge.html` report is suppressed as we are not using dials.merge to do the truncation, so no plot will be generated there.