### PR TITLE
Fix unicode logging errors on Windows

### DIFF
--- a/newsfragments/558.bugfix
+++ b/newsfragments/558.bugfix
@@ -1,0 +1,1 @@
+Fix unicode logging errors on Windows

--- a/src/xia2/Handlers/Streams.py
+++ b/src/xia2/Handlers/Streams.py
@@ -73,7 +73,7 @@ def setup_logging(logfile=None, debugfile=None, verbose=False):
     other_loggers = [logging.getLogger(package) for package in ("dials", "dxtbx")]
 
     if logfile:
-        fh = logging.FileHandler(filename=logfile, mode="w")
+        fh = logging.FileHandler(filename=logfile, mode="w", encoding="utf-8")
         fh.setLevel(loglevel)
         xia2_logger.addHandler(fh)
         for logger_ in other_loggers:
@@ -81,7 +81,7 @@ def setup_logging(logfile=None, debugfile=None, verbose=False):
             logger_.setLevel(loglevel)
 
     if debugfile:
-        fh = logging.FileHandler(filename=debugfile, mode="w")
+        fh = logging.FileHandler(filename=debugfile, mode="w", encoding="utf-8")
         fh.setLevel(logging.DEBUG)
         for logger_ in [xia2_logger] + other_loggers:
             logger_.addHandler(fh)


### PR DESCRIPTION
Writing utf-8 to a file that isn't utf-8 encoded causes xia2 to crash on Windows.

Resolves #558