### PR TITLE
Deliberately break the 'master' branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,6 @@ repos:
   - id: check-merge-conflict
   - id: check-added-large-files
     args: ['--maxkb=200']
+  - id: no-commit-to-branch
+    args: ['--branch', 'master']
+    name: "Don't commit to 'master'"

--- a/libtbx_refresh.py
+++ b/libtbx_refresh.py
@@ -2,6 +2,25 @@ import dials.precommitbx.nagger
 
 dials.precommitbx.nagger.nag()
 
+import libtbx.load_env
+
+exit(
+    ("=" * 80)
+    + """
+
+Your xia2 repository is still tracking 'master',
+but the main xia2 branch has been renamed to 'main'.
+
+Please go into your xia2 repository at %s and run the following commands:
+  git branch -m master main
+  git fetch origin
+  git branch -u origin/main main
+
+For more information please see https://github.com/xia2/xia2/issues/557
+"""
+    % libtbx.env.dist_path("xia2")
+)
+
 
 def _install_xia2_setup():
     """Install xia2 as a regular/editable python package"""

--- a/newsfragments/561.removal
+++ b/newsfragments/561.removal
@@ -1,0 +1,1 @@
+The main development branch of xia2 was renamed from 'master' to 'main'.

--- a/src/xia2/__init__.py
+++ b/src/xia2/__init__.py
@@ -2,3 +2,24 @@ import sys
 
 if sys.version_info.major == 2:
     sys.exit("Python 2 is no longer supported")
+
+import pathlib
+
+_xia2 = pathlib.Path(__file__).parents[2]
+
+exit(
+    ("=" * 80)
+    + """
+
+Your xia2 repository is still tracking 'master',
+but the main xia2 branch has been renamed to 'main'.
+
+Please go into your xia2 repository at %s and run the following commands:
+  git branch -m master main
+  git fetch origin
+  git branch -u origin/main main
+
+For more information please see https://github.com/xia2/xia2/issues/557
+"""
+    % _xia2
+)


### PR DESCRIPTION
in preparation to move to `main`.

Closes #557

It will tell developers and users how to get on the `main` branch. The corresponding first commit on `main` will be a 90% revert of this, leaving just the pre-commit and newsfragment in place. The pre-commit can than be removed after another transition period, say, 6 months.
