### PR TITLE
DIALS 3.3.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.2
+current_version = 3.3.3
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<release>[a-z]+)?(?P<patch>\d+)?

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.3.3 (2021-02-15)
+========================
+
+Bugfixes
+--------
+
+- Fix for missing ``SENSOR_THICKNESS=`` in XDS.INP generated for EIGER datasets introduced in 3.3.1 (`#564 <https://github.com/xia2/xia2/issues/564>`_)
+
+
 xia2 3.3.2 (2021-02-01)
 =======================
 

--- a/newsfragments/564.bugfix
+++ b/newsfragments/564.bugfix
@@ -1,0 +1,1 @@
+Fix for missing ``SENSOR_THICKNESS=`` in XDS.INP generated for EIGER datasets introduced in 3.3.1

--- a/newsfragments/564.bugfix
+++ b/newsfragments/564.bugfix
@@ -1,1 +1,0 @@
-Fix for missing ``SENSOR_THICKNESS=`` in XDS.INP generated for EIGER datasets introduced in 3.3.1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 # Version number is determined either by git revision (which takes precendence)
 # or a static version number which is updated by bump2version
-__version_tag__ = "3.3.2"
+__version_tag__ = "3.3.3"
 
 console_scripts = [
     "dev.xia2.check_mosaic=xia2.cli.check_mosaic:run",

--- a/src/xia2/Test/regression/expected/result.vxmi_thaumatin.3dii.7.1.9.0
+++ b/src/xia2/Test/regression/expected/result.vxmi_thaumatin.3dii.7.1.9.0
@@ -1,0 +1,22 @@
+Project: AUTOMATIC
+Crystal: DEFAULT
+Sequence length: 0
+Wavelength: NATIVE (0.97949)
+Sweep: SWEEP1
+Files ***
+Images: 1 to 20
+Beam 87.53 79.85 => 87.46 79.15
+Distance 194.50 => 194.48(0.1)
+Date: Thu Jan  1 00:00:00 1970
+For AUTOMATIC/DEFAULT/NATIVE:
+High resolution limit                           2.78(5%)    7.51(10%)    2.78(**)
+Low resolution limit                           27.34(5%)   27.34(**)    2.83(**)
+Completeness                                   13.1(5%)    10.9(5%)    13.2(10)
+Multiplicity                                    1.1(0.2)     1.0(0.2)     1.1(0.2)
+I/sigma                                        10.1(15%)    14.5(**)     4.8(0.3)
+Rmerge(I+/-)                                  0.035(10%)   0.024(10%)   0.234(15%)
+CC half                                       0.995(2%)   1.000(0.2)   0.952(0.2)
+Anomalous completeness                          0.2(2%)     0.0(5%)     1.1(10)
+Anomalous multiplicity                          1.1(0.5)     1.0(0.5)     1.0(0.5)
+Cell:  58.630(0.5%)  58.630(0.5%) 151.420(0.5%)  90.000  90.000  90.000
+Spacegroup: P 41 21 2

--- a/src/xia2/Test/regression/expected/result.vxmi_thaumatin.dials.7.1.9.0
+++ b/src/xia2/Test/regression/expected/result.vxmi_thaumatin.dials.7.1.9.0
@@ -1,0 +1,22 @@
+Project: AUTOMATIC
+Crystal: DEFAULT
+Sequence length: 0
+Wavelength: NATIVE (0.97949)
+Sweep: SWEEP1
+Files ***
+Images: 1 to 20
+Beam 87.53 79.85 => 87.45 79.15
+Distance 194.50 => 194.73(0.1)
+Date: Thu Jan  1 00:00:00 1970
+For AUTOMATIC/DEFAULT/NATIVE:
+High resolution limit                           3.54(5%)    9.48(10%)    3.54(**)
+Low resolution limit                           27.33(5%)   27.33(**)    3.60(**)
+Completeness                                   12.9(5%)    11.3(5%)    12.4(10)
+Multiplicity                                    1.1(0.2)     1.0(0.2)     1.2(0.2)
+I/sigma                                        13.5(15%)    21.6(**)    13.7(0.3)
+Rmerge(I+/-)                                  0.033(10%)   0.000(10%)   0.025(15%)
+CC half                                       0.996(2%)   0.000(0.2)   0.997(0.2)
+Anomalous completeness                          0.1(2%)     0.0(5%)     0.0(10)
+Anomalous multiplicity                          1.1(0.5)     1.0(0.5)     1.2(0.5)
+Cell:  58.608(0.5%)  58.608(0.5%) 151.378(0.5%)  90.000  90.000  90.000
+Spacegroup: P 41 21 2

--- a/src/xia2/Test/regression/test_vmxi_thaumatin.py
+++ b/src/xia2/Test/regression/test_vmxi_thaumatin.py
@@ -1,0 +1,27 @@
+import procrunner
+import pytest
+
+import xia2.Test.regression
+
+
+@pytest.mark.parametrize("pipeline", ["dials", "3dii"])
+def test_xia2(pipeline, regression_test, dials_data, tmpdir, ccp4):
+    master_h5 = dials_data("vmxi_thaumatin") / "image_15799_master.h5:1:20"
+    command_line = [
+        "xia2",
+        f"pipeline={pipeline}",
+        "nproc=1",
+        "trust_beam_centre=True",
+        "read_all_image_headers=False",
+        "space_group=P41212",
+        f"image={master_h5}",
+    ]
+    result = procrunner.run(command_line, working_directory=tmpdir)
+    success, issues = xia2.Test.regression.check_result(
+        f"vxmi_thaumatin.{pipeline}",
+        result,
+        tmpdir,
+        ccp4,
+        expected_space_group="P41212",
+    )
+    assert success, issues

--- a/src/xia2/Wrappers/XDS/XDS.py
+++ b/src/xia2/Wrappers/XDS/XDS.py
@@ -253,18 +253,17 @@ def imageset_to_xds(
     # based on wavelength. May be useful to override this for in vacuo exps
     # result.append('AIR=0.001')
 
-    if detector == "PILATUS":
+    if detector in ("PILATUS", "EIGER"):
         try:
             thickness = converter.get_detector()[0].get_thickness()
-            if not thickness:
-                thickness = 0.32
-                logger.debug(
-                    "Could not determine sensor thickness. Assuming default PILATUS 0.32mm"
-                )
         except Exception:
-            thickness = 0.32
+            thickness = None
+        if not thickness:
+            thickness = {"PILATUS": 0.32, "EIGER": 0.45}.get(detector)
             logger.debug(
-                "Error occured during sensor thickness determination. Assuming default PILATUS 0.32mm"
+                "Could not determine sensor thickness. Assuming default %s %.2f mm",
+                detector,
+                thickness,
             )
         result.append("SENSOR_THICKNESS=%f" % thickness)
 


### PR DESCRIPTION
- Fix for missing ``SENSOR_THICKNESS=`` in XDS.INP generated for EIGER datasets introduced in 3.3.1 (#564)