### PR TITLE
Update magic "reflections" number in tests 🎩 🐇

### DIFF
--- a/newsfragments/569.bugfix
+++ b/newsfragments/569.bugfix
@@ -1,0 +1,1 @@
+Fix tests affected by changes to profile fitting in `dials/dials#1297 <https://github.com/dials/dials/pull/1297>`

--- a/src/xia2/Test/Modules/Integrater/test_DialsIntegrater.py
+++ b/src/xia2/Test/Modules/Integrater/test_DialsIntegrater.py
@@ -57,7 +57,7 @@ def exercise_dials_integrater(dials_data, tmp_dir, nproc=None):
     reader = any_reflection_file(integrater_intensities)
     assert reader.file_type() == "ccp4_mtz", repr(integrater_intensities)
     mtz_object = reader.file_content()
-    expected_reflections = 47623
+    expected_reflections = 48482
     assert (
         abs(mtz_object.n_reflections() - expected_reflections) < 300
     ), mtz_object.n_reflections()


### PR DESCRIPTION
Due to changes from https://github.com/dials/dials/pull/1297 the normal, expected number of reflections has increased slightly. Increase that magic number so the test don't fail.

This currently fails with
```
>       assert (
            abs(mtz_object.n_reflections() - expected_reflections) < 300
        ), mtz_object.n_reflections()
E       AssertionError: 48482
E       assert 859 < 300
E        +  where 859 = abs((48482 - 47623))
E        +    where 48482 = <bound method n_reflections of <iotbx_mtz_ext.object object at 0x7f7982061430>>()
E        +      where <bound method n_reflections of <iotbx_mtz_ext.object object at 0x7f7982061430>> = <iotbx_mtz_ext.object object at 0x7f7982061430>.n_reflections
```