### PR TITLE
DIALS 3.4.2

### DIFF
--- a/newsfragments/579.bugfix
+++ b/newsfragments/579.bugfix
@@ -1,0 +1,1 @@
+Fix reading of split HKL files output from XSCALE

--- a/src/xia2/Modules/Scaler/XDSScalerHelpers.py
+++ b/src/xia2/Modules/Scaler/XDSScalerHelpers.py
@@ -69,7 +69,7 @@ class XDSScalerHelper:
                     break
 
                 for k in file_map:
-                    if "ISET" in line and int(line.split("ISET=")[1].split()[0]) != k:
+                    if "!ISET=" in line and int(line.split("ISET=")[1].split()[0]) != k:
                         continue
 
                     file_content[k].append(line)


### PR DESCRIPTION
Bugfixes
--------

- Fix reading of split HKL files output from XSCALE (#579)