### PR TITLE
Run tests on Azure in Python development mode

### DIFF
--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -77,7 +77,7 @@ steps:
     set -ux
     export DIALS_DATA=${PWD}/data
     cd modules/xia2
-    # export PYTHONDEVMODE=1
+    export PYTHONDEVMODE=1
     pytest -v -ra -n auto --basetemp="$(Pipeline.Workspace)/tests" --durations=10 \
         --cov=$(pwd) --cov-report=html --cov-report=xml --cov-branch \
         --timeout=5400 --regression-full || echo "##vso[task.complete result=Failed;]Some tests failed"

--- a/newsfragments/597.misc
+++ b/newsfragments/597.misc
@@ -1,0 +1,1 @@
+Run tests on Azure in Python development mode.


### PR DESCRIPTION
This currently causes tests to fail due to a dxtbx datablock `DeprecationWarning` showing up.

You can reproduce this easily with:
```bash
PYTHONDEVMODE=1 xia2.setup image=$(dials.data get insulin -q)/insulin_1_001.img read_all_image_headers=False >/dev/null
```