### PR TITLE
Saturated pixel checks

### DIFF
--- a/src/xia2/Handlers/Phil.py
+++ b/src/xia2/Handlers/Phil.py
@@ -21,6 +21,9 @@ general
   check_image_files_readable = True
     .type = bool
     .expert_level = 2
+  check_for_saturated_pixels = False
+    .type = bool
+    .expert_level = 2
 }
 xds
   .short_caption = "XDS settings"

--- a/src/xia2/Modules/Indexer/DialsIndexer.py
+++ b/src/xia2/Modules/Indexer/DialsIndexer.py
@@ -397,7 +397,7 @@ class DialsIndexer(Indexer):
                     logger.warn(
                         f"Near overloads found: {maximum_counts[3]} spots / {pixel_counts[3]} pixels"
                     )
-                logger.debug(f"Overload detection took {time.time() - t0}s")
+                logger.debug(f"Overload detection took {time.time() - t0:.2f}s")
 
             if not PhilIndex.params.dials.fast_mode:
                 detectblanks = self.DetectBlanks()

--- a/src/xia2/Wrappers/Dials/Spotfinder.py
+++ b/src/xia2/Wrappers/Dials/Spotfinder.py
@@ -33,6 +33,7 @@ def Spotfinder(DriverType=None):
             self._write_hot_mask = False
             self._hot_mask_prefix = None
             self._gain = None
+            self._maximum_trusted_value = None
 
         def set_input_sweep_filename(self, sweep_filename):
             self._input_sweep_filename = sweep_filename
@@ -88,6 +89,9 @@ def Spotfinder(DriverType=None):
         def set_gain(self, gain):
             self._gain = gain
 
+        def set_maximum_trusted_value(self, maximum_trusted_value):
+            self._maximum_trusted_value = maximum_trusted_value
+
         def run(self):
             logger.debug("Running dials.find_spots")
 
@@ -138,6 +142,10 @@ def Spotfinder(DriverType=None):
                 self.add_command_line("hot_mask_prefix=%s" % self._hot_mask_prefix)
             if self._gain:
                 self.add_command_line("gain=%f" % self._gain)
+            if self._maximum_trusted_value:
+                self.add_command_line(
+                    "maximum_trusted_value=%f" % self._maximum_trusted_value
+                )
             self.start()
             self.close_wait()
             self.check_for_errors()


### PR DESCRIPTION
Add checks for overloaded pixels to the spot finding, as well as an alert that spots are overloaded in stdout:

```
-------------------- Spotfinding SWEEP1 --------------------
67135 spots found on 450 images (max 1261 / bin)
*                                         *                *
* ** ********* *********************************************
************************************************************
************************************************************
************************************************************
************************************************************
************************************************************
************************************************************
************************************************************
************************************************************
1                         image                          450
Overloads found: 11 spots / 11 pixels
------------------- Autoindexing SWEEP1 --------------------
All possible indexing solutions:
cI  77.86  77.86  77.86  90.00  90.00  90.00
hR 110.05 110.05  67.45  90.00  90.00 120.00
tI  77.81  77.81  77.65  90.00  90.00  90.00
oI  77.66  77.81  77.84  90.00  90.00  90.00
oF  77.65 110.01 110.05  90.00  90.00  90.00
mC 109.88  77.83  77.64  90.00 134.93  90.00
aP  67.38  67.32  67.31 109.36 109.46 109.59
Indexing solution:
cI  77.86  77.86  77.86  90.00  90.00  90.00
-------------------- Integrating SWEEP1 --------------------
```

Currently controlled by a PHIL parameter 

```
general.check_for_saturated_pixels=True
```

