### PR TITLE
xia2.compare_merging_stats matplotlib warning workaround

### DIFF
--- a/newsfragments/634.bugfix
+++ b/newsfragments/634.bugfix
@@ -1,0 +1,1 @@
+Workaround to suppress a warning emitted by ``xia2.compare_merging_stats``

--- a/src/xia2/cli/compare_merging_stats.py
+++ b/src/xia2/cli/compare_merging_stats.py
@@ -318,6 +318,7 @@ def plot_data(
             else:
                 ax.set_ylim(0)
             xticks = ax.get_xticks()
+            ax.set_xticks(ax.get_xticks().tolist())
             xticks_d = [
                 "%.2f" % uctbx.d_star_sq_as_d(ds2) if ds2 > 0 else 0 for ds2 in xticks
             ]


### PR DESCRIPTION
Simple solution taken from https://github.com/amueller/dabl/commit/dd9a56a132eee4cd5bc61ef25462d06aae336bf8.