### PR TITLE
Reapply pre-commit updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # Syntax validation and some basic sanity checks
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
   - id: check-merge-conflict
   - id: check-ast
@@ -15,7 +15,7 @@ repos:
 
 # Automatically sort imports
 - repo: https://github.com/PyCQA/isort
-  rev: 5.9.3
+  rev: 5.10.1
   hooks:
   - id: isort
     args: [
@@ -32,14 +32,14 @@ repos:
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black
-  rev: 21.6b0
+  rev: 21.12b0
   hooks:
   - id: black
     args: [--safe, --quiet]
 
 # Linting
 - repo: https://github.com/PyCQA/flake8
-  rev: 3.9.2
+  rev: 4.0.1
   hooks:
   - id: flake8
-    additional_dependencies: ['flake8-comprehensions==3.5.0']
+    additional_dependencies: ['flake8-comprehensions==3.8.0']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black
-  rev: 21.12b0
+  rev: 22.1.0
   hooks:
   - id: black
     args: [--safe, --quiet]

--- a/conftest.py
+++ b/conftest.py
@@ -60,7 +60,7 @@ def ccp4():
         pytest.skip(
             "CCP4 installation required for this test - Could not run CCP4 executable"
         )
-    version = re.search(br"patch level *([0-9]+)\.([0-9]+)\.([0-9]+)", result.stdout)
+    version = re.search(rb"patch level *([0-9]+)\.([0-9]+)\.([0-9]+)", result.stdout)
     if not version:
         pytest.skip(
             "CCP4 installation required for this test - Could not determine CCP4 version"
@@ -78,7 +78,7 @@ def xds():
         result = procrunner.run(["xds"], print_stdout=False)
     except OSError:
         pytest.skip("XDS installation required for this test")
-    version = re.search(br"BUILT=([0-9]+)\)", result.stdout)
+    version = re.search(rb"BUILT=([0-9]+)\)", result.stdout)
     if version:
         return {"version": int(version.groups()[0])}
     if result.returncode:

--- a/newsfragments/648.misc
+++ b/newsfragments/648.misc
@@ -1,0 +1,1 @@
+Update pre-commit environments

--- a/src/xia2/Handlers/Versions.py
+++ b/src/xia2/Handlers/Versions.py
@@ -50,7 +50,7 @@ def get_xds_version():
         )
     except OSError:
         pass
-    version = re.search(br"BUILT=([0-9]+)\)", result.stdout)
+    version = re.search(rb"BUILT=([0-9]+)\)", result.stdout)
     if version:
         return int(version.groups()[0])
     return None
@@ -64,7 +64,7 @@ def get_aimless_version():
         print_stderr=False,
         stdin=subprocess.DEVNULL,
     )
-    version = re.search(br"version\s\d+\.\d+\.\d+", result.stdout)
+    version = re.search(rb"version\s\d+\.\d+\.\d+", result.stdout)
     if version:
         return version.group().decode("utf-8").split(" ")[1]
     return None
@@ -75,7 +75,7 @@ def get_pointless_version():
     result = procrunner.run(
         ["pointless"], print_stdout=False, print_stderr=False, stdin=subprocess.DEVNULL
     )
-    version = re.search(br"version\s\d+\.\d+\.\d+", result.stdout)
+    version = re.search(rb"version\s\d+\.\d+\.\d+", result.stdout)
     if version:
         return version.group().decode("utf-8").split(" ")[1]
     return None

--- a/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
@@ -284,7 +284,7 @@ class DataManager:
         n = int(math.ceil(math.log10(max_batches)))
 
         for i, expt in enumerate(self._experiments):
-            expt.scan.set_batch_offset(i * 10 ** n)
+            expt.scan.set_batch_offset(i * 10**n)
             # This may be a different scan instance ¯\_(ツ)_/¯
             expt.imageset.get_scan().set_batch_offset(expt.scan.get_batch_offset())
             logger.debug(

--- a/src/xia2/Toolkit/NPP.py
+++ b/src/xia2/Toolkit/NPP.py
@@ -9,7 +9,7 @@ from scitbx.math import distributions
 def mean_variance(values):
     m = flex.sum(values) / values.size()
     m2 = flex.sum(values * values) / values.size()
-    v = m2 - m ** 2
+    v = m2 - m**2
     return m, v
 
 

--- a/src/xia2/cli/compare_merging_stats.py
+++ b/src/xia2/cli/compare_merging_stats.py
@@ -252,7 +252,7 @@ def plot_data(
 
     @ticker.FuncFormatter
     def resolution_formatter(d_star_sq, pos):
-        d = 1 / d_star_sq ** 0.5 if d_star_sq > 0 else 0
+        d = 1 / d_star_sq**0.5 if d_star_sq > 0 else 0
         return f"{d:.2f}"
 
     colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]

--- a/src/xia2/cli/to_shelx.py
+++ b/src/xia2/cli/to_shelx.py
@@ -59,7 +59,7 @@ Winter, G. (2010) Journal of Applied Crystallography 43
         return (
             "%%.%df(%%d)"
             % decimal_places
-            % (value, round(esd * (10 ** decimal_places)))
+            % (value, round(esd * (10**decimal_places)))
         )
 
     if unit_cell_data:

--- a/tests/regression/test_X4_wide.py
+++ b/tests/regression/test_X4_wide.py
@@ -49,14 +49,10 @@ def test_incompatible_pipeline_scaler(pipeline, scaler, tmpdir, ccp4):
     command_line = ["xia2", "pipeline=%s" % pipeline, "nproc=1", "scaler=%s" % scaler]
     result = procrunner.run(command_line, working_directory=tmpdir)
     assert result.returncode
-    assert (
-        "Error: scaler=%s not compatible with pipeline=%s"
-        % (
-            scaler,
-            pipeline,
-        )
-        in result.stdout.decode("latin-1")
-    )
+    assert "Error: scaler=%s not compatible with pipeline=%s" % (
+        scaler,
+        pipeline,
+    ) in result.stdout.decode("latin-1")
 
 
 def test_dials_aimless(regression_test, dials_data, tmpdir, ccp4):


### PR DESCRIPTION
This reapplies the changes that were reverted in https://github.com/xia2/xia2/commit/d6c13c02d4146006eeb571c6b5f069b53c1d7964.

At time of writing, there is a setuptools/virtualenv versioning problem that means it's highly likely that updating pre-commit environments will break, unless every user and location that runs pre-commit is updated to force the old behaviour.

Since there's no way to do this in-precommit and it looks like pre-commit wants to just wait out the storm, we won't change pre-commits for users for a while, until this storm is over.

For details see https://github.com/pre-commit/pre-commit/issues/2178