### PR TITLE
Remove a few unnecessary `run_in_tmpdir` instances

### DIFF
--- a/newsfragments/658.misc
+++ b/newsfragments/658.misc
@@ -1,0 +1,1 @@
+Test modernisations: Remove some run_in_tmpdir usage, update py.path to pathlib.Path

--- a/tests/Applications/test_xia2setup.py
+++ b/tests/Applications/test_xia2setup.py
@@ -12,85 +12,85 @@ def insulin_with_missing_image(dials_data, tmp_path):
         if j == 23:
             continue
         tmp_path.joinpath(f"insulin_1_{j:03d}.img").symlink_to(
-            dials_data("insulin").join(f"insulin_1_{j:03d}.img")
+            dials_data("insulin", pathlib=True) / f"insulin_1_{j:03d}.img"
         )
-    return tmp_path.joinpath("insulin_1_###.img")
+    return tmp_path / "insulin_1_###.img"
 
 
-def test_write_xinfo_insulin_with_missing_image(
-    insulin_with_missing_image, run_in_tmpdir
-):
+def test_write_xinfo_insulin_with_missing_image(insulin_with_missing_image, tmp_path):
     result = procrunner.run(
         [
             "xia2.setup",
             f"image={insulin_with_missing_image.parent.joinpath('insulin_1_001.img')}",
         ],
-        environment_override={"CCP4": run_in_tmpdir},
+        environment_override={"CCP4": tmp_path},
+        working_directory=tmp_path,
     )
     assert not result.returncode
     assert not result.stderr
-    xinfo = run_in_tmpdir.join("automatic.xinfo")
-    assert xinfo.check(file=1)
+    xinfo = tmp_path / "automatic.xinfo"
+    assert xinfo.is_file()
     x = XInfo(xinfo)
     assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 2
     assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 22]
     assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [24, 45]
 
 
-def test_write_xinfo_template_missing_images(insulin_with_missing_image, run_in_tmpdir):
+def test_write_xinfo_template_missing_images(insulin_with_missing_image, tmp_path):
     result = procrunner.run(
         [
             "xia2.setup",
             f"image={insulin_with_missing_image.parent.joinpath('insulin_1_001.img:1:22')}",
             "read_all_image_headers=False",
         ],
-        environment_override={"CCP4": run_in_tmpdir},
+        environment_override={"CCP4": tmp_path},
+        working_directory=tmp_path,
     )
     assert not result.returncode
     assert not result.stderr
-    xinfo = run_in_tmpdir.join("automatic.xinfo")
-    assert xinfo.check(file=1)
+    xinfo = tmp_path / "automatic.xinfo"
+    assert xinfo.is_file()
     x = XInfo(xinfo)
     assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 1
     assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 22]
 
 
-def test_write_xinfo_split_sweep(dials_data, tmpdir):
+def test_write_xinfo_split_sweep(dials_data, tmp_path):
     result = procrunner.run(
         [
             "xia2.setup",
-            f"image={dials_data('insulin').join('insulin_1_001.img:1:22')}",
-            f"image={dials_data('insulin').join('insulin_1_001.img:23:45')}",
+            f"image={dials_data('insulin', pathlib=True) / 'insulin_1_001.img:1:22'}",
+            f"image={dials_data('insulin', pathlib=True) / 'insulin_1_001.img:23:45'}",
             "read_all_image_headers=False",
         ],
-        working_directory=tmpdir,
-        environment_override={"CCP4": tmpdir},
+        environment_override={"CCP4": tmp_path},
+        working_directory=tmp_path,
     )
     assert not result.returncode
     assert not result.stderr
-    xinfo = tmpdir.join("automatic.xinfo")
-    assert xinfo.check(file=1)
+    xinfo = tmp_path / "automatic.xinfo"
+    assert xinfo.is_file()
     x = XInfo(xinfo)
     assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 2
     assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 22]
     assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP2"]["start_end"] == [23, 45]
 
 
-def test_write_xinfo_unroll(dials_data, tmpdir):
+def test_write_xinfo_unroll(dials_data, tmp_path):
     # This test partially exercises the fix to https://github.com/xia2/xia2/issues/498 with a different syntax
     result = procrunner.run(
         [
             "xia2.setup",
-            f"image={dials_data('insulin').join('insulin_1_001.img:1:45:15')}",
+            f"image={dials_data('insulin', pathlib=True) / 'insulin_1_001.img:1:45:15'}",
             "read_all_image_headers=False",
         ],
-        working_directory=tmpdir,
-        environment_override={"CCP4": tmpdir},
+        environment_override={"CCP4": tmp_path},
+        working_directory=tmp_path,
     )
     assert not result.returncode
     assert not result.stderr
-    xinfo = tmpdir.join("automatic.xinfo")
-    assert xinfo.check(file=1)
+    xinfo = tmp_path / "automatic.xinfo"
+    assert xinfo.is_file()
     x = XInfo(xinfo)
     assert len(x.get_crystals()["DEFAULT"]["sweeps"]) == 3
     assert x.get_crystals()["DEFAULT"]["sweeps"]["SWEEP1"]["start_end"] == [1, 15]

--- a/tests/regression/test_multiple_sweeps.py
+++ b/tests/regression/test_multiple_sweeps.py
@@ -18,7 +18,7 @@ import pytest
     "multi_sweep_type",
     ("multi_sweep_indexing", "multi_sweep_refinement", "small_molecule"),
 )
-def test_multiple_sweeps(multi_sweep_type, ccp4, dials_data, run_in_tmpdir):
+def test_multiple_sweeps(multi_sweep_type, ccp4, dials_data, tmp_path):
     """
     Run xia2 with various different multiple-sweep options.
 
@@ -29,13 +29,12 @@ def test_multiple_sweeps(multi_sweep_type, ccp4, dials_data, run_in_tmpdir):
 
     Args:
         multi_sweep_type: Parameter governing multiple-sweep behaviour to be set True.
-        dials_data: DIALS custom Pytest fixture for access to test data.
-        run_in_tmpdir: DIALS custom Pytest fixture to run this test in a temporary
-                       directory.
+        dials_data: dials-data pytest fixture for access to test data.
+        tmp_path: pytest fixture to provide a temporary working directory
     """
     # Use as input the first fifteen images of the first two sweeps of a typical
     # multiple-sweep data set.
-    data_dir = dials_data("l_cysteine_dials_output")
+    data_dir = dials_data("l_cysteine_dials_output", pathlib=True)
     images = [data_dir / f"l-cyst_{sweep:02d}_00001.cbf:1:15" for sweep in (1, 2)]
 
     command = [
@@ -49,6 +48,9 @@ def test_multiple_sweeps(multi_sweep_type, ccp4, dials_data, run_in_tmpdir):
         # Don't run the Xtriage analysis — we don't have enough reflections overall.
         "xtriage_analysis=False",
     ]
-    result = procrunner.run(command + [f"image={image}" for image in images])
+    result = procrunner.run(
+        command + [f"image={str(image)}" for image in images],
+        working_directory=tmp_path,
+    )
 
     assert not result.returncode


### PR DESCRIPTION
`run_in_tmpdir` is bad, as the working directory is a global singleton.

This removes a few unnecessary instances, and also updates some dials_data calls to use `pathlib.Path`s in more places