### PR TITLE
Use smaller datasets in some regression tests

### DIFF
--- a/newsfragments/664.misc
+++ b/newsfragments/664.misc
@@ -1,0 +1,1 @@
+Improved test runtimes and CI coverage.

--- a/tests/Modules/Indexer/test_DIALS_indexer.py
+++ b/tests/Modules/Indexer/test_DIALS_indexer.py
@@ -16,11 +16,10 @@ from xia2.Schema.XSweep import XSweep
 from xia2.Schema.XWavelength import XWavelength
 
 
-def exercise_dials_indexer(dials_data, tmp_path, nproc=None):
-    if nproc is not None:
-        PhilIndex.params.xia2.settings.multiprocessing.nproc = nproc
+def _exercise_dials_indexer(dials_data, tmp_path):
+    PhilIndex.params.xia2.settings.multiprocessing.nproc = 1
 
-    template = dials_data("insulin", pathlib=True) / "insulin_1_###.img"
+    template = dials_data("centroid_test_data", pathlib=True) / "centroid_####.cbf"
 
     indexer = DialsIndexer()
     indexer.set_working_directory(os.fspath(tmp_path))
@@ -39,18 +38,16 @@ def exercise_dials_indexer(dials_data, tmp_path, nproc=None):
     indexer.index()
 
     assert indexer.get_indexer_cell() == pytest.approx(
-        (78.14, 78.14, 78.14, 90, 90, 90), rel=1e-3
+        (42.20, 42.20, 39.68, 90, 90, 90), rel=1e-3
     )
     solution = indexer.get_solution()
-    assert solution["rmsd"] == pytest.approx(0.03545, abs=1e-3)
-    assert solution["metric"] == pytest.approx(0.02517, abs=5e-3)
-    assert solution["number"] == 22
-    assert solution["lattice"] == "cI"
+    assert solution["rmsd"] == pytest.approx(0.09241, abs=1e-3)
+    assert solution["metric"] == pytest.approx(0.34599, abs=5e-3)
+    assert solution["number"] == 9
+    assert solution["lattice"] == "tP"
 
     beam_centre = indexer.get_indexer_beam_centre()
-    assert beam_centre == pytest.approx(
-        (94.41567208118963, 94.51337522659865), abs=1e-3
-    )
+    assert beam_centre == pytest.approx((219.8758, 212.6103), abs=1e-3)
     print(indexer.get_indexer_experiment_list()[0].crystal)
     print(indexer.get_indexer_experiment_list()[0].detector)
 
@@ -68,10 +65,10 @@ def exercise_dials_indexer(dials_data, tmp_path, nproc=None):
     indexer2.eliminate()
 
     assert indexer.get_indexer_cell() == pytest.approx(indexer2.get_indexer_cell())
-    assert indexer.get_indexer_lattice() == "hR"
-    assert indexer2.get_indexer_lattice() == "hR"
+    assert indexer.get_indexer_lattice() == "oC"
+    assert indexer2.get_indexer_lattice() == "oC"
 
 
-def test_dials_indexer_serial(regression_test, ccp4, dials_data, run_in_tmp_path):
+def test_dials_indexer_serial(ccp4, dials_data, run_in_tmp_path):
     with mock.patch.object(sys, "argv", []):
-        exercise_dials_indexer(dials_data, run_in_tmp_path, nproc=1)
+        _exercise_dials_indexer(dials_data, run_in_tmp_path)

--- a/tests/Modules/Integrater/test_DialsIntegrater.py
+++ b/tests/Modules/Integrater/test_DialsIntegrater.py
@@ -23,7 +23,7 @@ from xia2.Schema.XWavelength import XWavelength
 def _exercise_dials_integrater(dials_data, tmp_path):
     PhilIndex.params.xia2.settings.multiprocessing.nproc = 1
 
-    template = dials_data("insulin", pathlib=True) / "insulin_1_###.img"
+    template = dials_data("centroid_test_data", pathlib=True) / "centroid_####.cbf"
 
     indexer = DialsIndexer()
     indexer.set_working_directory(os.fspath(tmp_path))
@@ -41,14 +41,12 @@ def _exercise_dials_integrater(dials_data, tmp_path):
     refiner = DialsRefiner()
     refiner.set_working_directory(os.fspath(tmp_path))
     refiner.add_refiner_indexer(sweep.get_epoch(1), indexer)
-    # refiner.refine()
 
     integrater = DialsIntegrater()
     integrater.set_output_format("hkl")
     integrater.set_working_directory(os.fspath(tmp_path))
     integrater.setup_from_image(imageset.get_path(1))
     integrater.set_integrater_refiner(refiner)
-    # integrater.set_integrater_indexer(indexer)
     integrater.set_integrater_sweep(sweep)
     integrater.integrate()
 
@@ -58,10 +56,8 @@ def _exercise_dials_integrater(dials_data, tmp_path):
     reader = any_reflection_file(integrater_intensities)
     assert reader.file_type() == "ccp4_mtz", repr(integrater_intensities)
     mtz_object = reader.file_content()
-    expected_reflections = 48482
-    assert (
-        abs(mtz_object.n_reflections() - expected_reflections) < 300
-    ), mtz_object.n_reflections()
+    expected_reflections = 519
+    assert mtz_object.n_reflections() == pytest.approx(expected_reflections, abs=10)
 
     assert mtz_object.column_labels() == [
         "H",
@@ -83,9 +79,9 @@ def _exercise_dials_integrater(dials_data, tmp_path):
         "QE",
     ]
 
-    assert integrater.get_integrater_wedge() == (1, 45)
+    assert integrater.get_integrater_wedge() == (1, 9)
     assert integrater.get_integrater_cell() == pytest.approx(
-        (78.14, 78.14, 78.14, 90, 90, 90), abs=1e-1
+        (42.20, 42.20, 39.68, 90, 90, 90), abs=0.1
     )
 
     # test serialization of integrater
@@ -102,9 +98,7 @@ def _exercise_dials_integrater(dials_data, tmp_path):
     reader = any_reflection_file(integrater2_intensities)
     assert reader.file_type() == "ccp4_mtz"
     mtz_object = reader.file_content()
-    assert (
-        abs(mtz_object.n_reflections() - expected_reflections) < 300
-    ), mtz_object.n_reflections()
+    assert mtz_object.n_reflections() == pytest.approx(expected_reflections, abs=10)
 
     integrater2.set_integrater_done(False)
     integrater2_intensities = integrater2.get_integrater_intensities()
@@ -112,9 +106,7 @@ def _exercise_dials_integrater(dials_data, tmp_path):
     reader = any_reflection_file(integrater2_intensities)
     assert reader.file_type() == "ccp4_mtz"
     mtz_object = reader.file_content()
-    assert (
-        abs(mtz_object.n_reflections() - expected_reflections) < 300
-    ), mtz_object.n_reflections()
+    assert mtz_object.n_reflections() == pytest.approx(expected_reflections, abs=10)
 
     integrater2.set_integrater_prepare_done(False)
     integrater2_intensities = integrater2.get_integrater_intensities()
@@ -122,9 +114,7 @@ def _exercise_dials_integrater(dials_data, tmp_path):
     reader = any_reflection_file(integrater2_intensities)
     assert reader.file_type() == "ccp4_mtz"
     mtz_object = reader.file_content()
-    assert (
-        abs(mtz_object.n_reflections() - expected_reflections) < 300
-    ), mtz_object.n_reflections()
+    assert mtz_object.n_reflections() == pytest.approx(expected_reflections, abs=10)
 
     # Test that diamond anvil cell attenuation correction does something.
     # That it does the right thing is left as a matter for the DIALS tests.

--- a/tests/Modules/Integrater/test_XDSIntegrater.py
+++ b/tests/Modules/Integrater/test_XDSIntegrater.py
@@ -22,7 +22,7 @@ from xia2.Schema.XWavelength import XWavelength
 def _exercise_xds_integrater(dials_data, tmp_path):
     PhilIndex.params.xia2.settings.multiprocessing.nproc = 1
 
-    template = dials_data("insulin", pathlib=True) / "insulin_1_###.img"
+    template = dials_data("centroid_test_data", pathlib=True) / "centroid_####.cbf"
 
     indexer = XDSIndexer()
     indexer.set_working_directory(os.fspath(tmp_path))
@@ -55,7 +55,7 @@ def _exercise_xds_integrater(dials_data, tmp_path):
     reader = any_reflection_file(integrater_intensities)
     assert reader.file_type() == "ccp4_mtz"
     mtz_object = reader.file_content()
-    assert mtz_object.n_reflections() == pytest.approx(50000, abs=400)
+    assert mtz_object.n_reflections() == pytest.approx(1409, abs=12)
     assert mtz_object.column_labels() == [
         "H",
         "K",
@@ -77,14 +77,14 @@ def _exercise_xds_integrater(dials_data, tmp_path):
     reader = any_reflection_file(corrected_intensities)
     assert reader.file_type() == "xds_ascii"
     ma = reader.as_miller_arrays(merge_equivalents=False)[0]
-    assert ma.size() == pytest.approx(50000, abs=400)
+    assert ma.size() == pytest.approx(1409, abs=12)
 
-    assert integrater.get_integrater_wedge() == (1, 45)
+    assert integrater.get_integrater_wedge() == (1, 9)
     assert integrater.get_integrater_cell() == pytest.approx(
-        (78.066, 78.066, 78.066, 90, 90, 90), abs=1
+        (42.175, 42.175, 39.652, 90, 90, 90), abs=1
     )
     assert integrater.get_integrater_mosaic_min_mean_max() == pytest.approx(
-        (0.180, 0.180, 0.180), abs=1e-1
+        (0.187, 0.187, 0.187), abs=0.1
     )
 
     # test serialization of integrater
@@ -101,7 +101,7 @@ def _exercise_xds_integrater(dials_data, tmp_path):
     reader = any_reflection_file(integrater2_intensities)
     assert reader.file_type() == "ccp4_mtz"
     mtz_object = reader.file_content()
-    assert mtz_object.n_reflections() == pytest.approx(50000, abs=400)
+    assert mtz_object.n_reflections() == pytest.approx(1409, abs=12)
 
     integrater2.set_integrater_done(False)
     integrater2_intensities = integrater2.get_integrater_intensities()
@@ -109,7 +109,7 @@ def _exercise_xds_integrater(dials_data, tmp_path):
     reader = any_reflection_file(integrater2_intensities)
     assert reader.file_type() == "ccp4_mtz"
     mtz_object = reader.file_content()
-    assert mtz_object.n_reflections() == pytest.approx(50000, abs=450)
+    assert mtz_object.n_reflections() == pytest.approx(1413, abs=12)
 
     integrater2.set_integrater_prepare_done(False)
     integrater2_intensities = integrater2.get_integrater_intensities()
@@ -117,9 +117,9 @@ def _exercise_xds_integrater(dials_data, tmp_path):
     reader = any_reflection_file(integrater2_intensities)
     assert reader.file_type() == "ccp4_mtz"
     mtz_object = reader.file_content()
-    assert mtz_object.n_reflections() == pytest.approx(50100, abs=400)
+    assert mtz_object.n_reflections() == pytest.approx(1420, abs=12)
 
 
-def test_xds_integrater_serial(regression_test, ccp4, xds, dials_data, run_in_tmp_path):
+def test_xds_integrater_serial(ccp4, xds, dials_data, run_in_tmp_path):
     with mock.patch.object(sys, "argv", []):
         _exercise_xds_integrater(dials_data, run_in_tmp_path)

--- a/tests/Modules/Scaler/test_CCP4ScalerA.py
+++ b/tests/Modules/Scaler/test_CCP4ScalerA.py
@@ -10,7 +10,7 @@ def test_ccp4_scalerA(regression_test, ccp4, dials_data, run_in_tmp_path):
 
     PhilIndex.params.xia2.settings.multiprocessing.nproc = 1
 
-    template = dials_data("insulin", pathlib=True) / "insulin_1_###.img"
+    template = dials_data("centroid_test_data", pathlib=True) / "centroid_####.cbf"
 
     tmpdir = str(run_in_tmp_path)
 

--- a/tests/Schema/test_XProject.py
+++ b/tests/Schema/test_XProject.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 
 def _exercise_serialization(dials_data, tmp_path):
-    template = dials_data("insulin", pathlib=True) / "insulin_1_###.img"
+    template = dials_data("centroid_test_data", pathlib=True) / "centroid_####.cbf"
 
     from dxtbx.model import ExperimentList
 

--- a/tests/Wrappers/Dials/test_dials_wrappers.py
+++ b/tests/Wrappers/Dials/test_dials_wrappers.py
@@ -26,8 +26,8 @@ from xia2.Wrappers.Dials.Spotfinder import Spotfinder
 def _exercise_dials_wrappers(image_file):
     PhilIndex.params.xia2.settings.multiprocessing.nproc = 1
 
-    scan_ranges = [(1, 45)]
-    image_range = (1, 45)
+    scan_ranges = [(1, 9)]
+    image_range = (1, 9)
 
     print("Begin importing")
     importer = Import()
@@ -60,20 +60,20 @@ def _exercise_dials_wrappers(image_file):
     rbs.run()
     print("".join(rbs.get_all_output()))
     print("Done refining")
-    bravais_setting_22 = rbs.get_bravais_summary()[22]
-    assert bravais_setting_22["bravais"] == "cI"
-    assert bravais_setting_22["cb_op"] == "b+c,a+c,a+b"
-    assert bravais_setting_22["unit_cell"] == pytest.approx(
-        (78.14, 78.14, 78.14, 90, 90, 90), abs=1e-1
+    bravais_setting_9 = rbs.get_bravais_summary()[9]
+    assert bravais_setting_9["bravais"] == "tP"
+    assert bravais_setting_9["cb_op"] == "b,c,a"
+    assert bravais_setting_9["unit_cell"] == pytest.approx(
+        (42.18, 42.18, 39.66, 90, 90, 90), abs=0.1
     )
-    bravais_setting_22_json = bravais_setting_22["experiments_file"]
-    assert os.path.exists(bravais_setting_22_json)
+    bravais_setting_9_json = bravais_setting_9["experiments_file"]
+    assert os.path.exists(bravais_setting_9_json)
 
     print("Begin reindexing")
     reindexer = Reindex()
     reindexer.set_experiments_filename(indexer.get_experiments_filename())
     reindexer.set_indexed_filename(indexer.get_indexed_filename())
-    reindexer.set_cb_op(bravais_setting_22["cb_op"])
+    reindexer.set_cb_op(bravais_setting_9["cb_op"])
     reindexer.run()
     assert os.path.exists(reindexer.get_reindexed_experiments_filename())
     assert os.path.exists(reindexer.get_reindexed_reflections_filename())
@@ -82,7 +82,7 @@ def _exercise_dials_wrappers(image_file):
 
     print("Begin refining")
     refiner = Refine()
-    refiner.set_experiments_filename(bravais_setting_22_json)
+    refiner.set_experiments_filename(bravais_setting_9_json)
     refiner.set_indexed_filename(reindexer.get_reindexed_reflections_filename())
     refiner.set_scan_varying(True)
     refiner.run()
@@ -140,7 +140,7 @@ def _exercise_dials_wrappers(image_file):
     assert os.path.exists(exporter.get_combined_reflections_filename())
 
 
-def test_dials_wrappers_serial(regression_test, ccp4, dials_data, run_in_tmp_path):
-    image_file = dials_data("insulin", pathlib=True) / "insulin_1_001.img"
+def test_dials_wrappers_serial(dials_data, run_in_tmp_path):
+    image_file = dials_data("centroid_test_data", pathlib=True) / "centroid_0001.cbf"
     with mock.patch.object(sys, "argv", []):
         _exercise_dials_wrappers(image_file)


### PR DESCRIPTION
Instead of the relatively large 'insulin' dataset use
'centroid-test-data' for some regression tests.

This reduces test times between 50% and 75% for the modified tests,
and allows more tests to be enabled to run without `--regression-full`.

Two tests were enabled to run on Azure (one due to runtime reduction,
the other due to runtime reduction and the removal of an incorrect CCP4
dependency declaration)