### PR TITLE
Bugfix for finding NeXus data

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,2 @@
+xia2 with NeXus files: if the NeXus files are not from an Eiger some are ignored, as the /entry/data/data_[nnnn] entries do not exist -> in this case accept the data as passed in rather than trying to do "clever workarounds"
+

--- a/src/xia2/Applications/xia2setup.py
+++ b/src/xia2/Applications/xia2setup.py
@@ -247,6 +247,9 @@ def _filter_aliased_hdf5_sweeps(sweeps):
                 rest.append(s)
             continue
         filenames = tuple(_list_hdf5_data_files(s))
+        if not filenames and s not in rest:
+            rest.append(s)
+            continue
         if filenames in h5_data_to_sweep:
             # impose slight bias in favour of using _master.h5 in place of .nxs
             # because XDS


### PR DESCRIPTION
If the data are not following the Eiger conventions but are otherwise correct they may be ignored (to be precise: second and subsequent sweeps may be ignored which is frustrating) - handle that by simply taking data as written if they are following the normal convention.

Fixes #671

The fix for this is not pretty and indicates that a proper refactor of this whole area would be appropriate