### PR TITLE
Fix error in xia2.ssx progress reporting when no hits in a batch, or no images indexed in a batch

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``xia2.ssx``: Fix error in progress reporting when no hits found or when no images indexed in a batch

--- a/src/xia2/Modules/SSX/data_integration_programs.py
+++ b/src/xia2/Modules/SSX/data_integration_programs.py
@@ -360,7 +360,7 @@ def ssx_index(
             summary_plots = {}
             if indexed_experiments:
                 summary_plots = generate_plots(summary_data)
-            indexing_rate = f"{100 * n_images / n_hits:.2f}"
+            indexing_rate = f"{100 * n_images / n_hits:.2f}" if n_hits else "-"
             output_ = (
                 f"{indexed_reflections.size()} spots indexed on {n_images} images ({indexing_rate}% of hits indexed)\n"
                 + f"{indexing_summary_output(summary_data, summary_plots)}"


### PR DESCRIPTION
Fixes a miscalculation of the integration rate added in https://github.com/xia2/xia2/commit/399ae8e73040d22c7fa1a162a2aba849ebdb5ffe and a ZeroDivisionError when no hits occur in a batch