### PR TITLE
DIALS 3.15.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.15.0
+current_version = 3.15.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<release>[a-z]+)?(?P<patch>\d+)?

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+xia2 3.15.1 (2023-06-29)
+========================
+
+Bugfixes
+--------
+
+- Don't import matplotlib in scipy.hierarchy.dendrrogram, causing errors on headless machines. (`#745 <https://github.com/xia2/xia2/issues/745>`_)
+
+
 xia2 3.15.0 (2023-06-13)
 ========================
 

--- a/newsfragments/745.bugfix
+++ b/newsfragments/745.bugfix
@@ -1,1 +1,0 @@
-Don't import matplotlib in scipy.hierarchy.dendrrogram, causing errors on headless machines.

--- a/newsfragments/745.bugfix
+++ b/newsfragments/745.bugfix
@@ -1,0 +1,1 @@
+Don't import matplotlib in scipy.hierarchy.dendrrogram, causing errors on headless machines.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import setuptools
 
 # Version number, or fallback version number for non-releases.
 # This should be updated by bump2version, not manually.
-__version_tag__ = "3.15.0"
+__version_tag__ = "3.15.1"
 
 console_scripts = [
     "dev.xia2.check_mosaic=xia2.cli.check_mosaic:run",


### PR DESCRIPTION
Bugfixes
--------

- Don't import matplotlib in scipy.hierarchy.dendrrogram, causing errors on headless machines. (#745)