### PR TITLE
Multiplex reindex to ref

### DIFF
--- a/newsfragments/xxx.feature
+++ b/newsfragments/xxx.feature
@@ -1,0 +1,1 @@
+``xia2.multiplex``: Added option to use a reference pdb for consistent indexing

--- a/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
@@ -28,6 +28,7 @@ from xia2.Modules.Scaler.DialsScaler import (
 from xia2.Wrappers.Dials.Cosym import DialsCosym
 from xia2.Wrappers.Dials.EstimateResolution import EstimateResolution
 from xia2.Wrappers.Dials.Refine import Refine
+from xia2.Wrappers.Dials.Reindex import Reindex
 from xia2.Wrappers.Dials.Scale import DialsScale
 from xia2.Wrappers.Dials.Symmetry import DialsSymmetry
 from xia2.Wrappers.Dials.TwoThetaRefine import TwoThetaRefine
@@ -137,6 +138,16 @@ symmetry
             "analysis of systematically absent reflections to determine the space group."
     .short_caption = "Space group"
 }
+
+reference = None
+    .type = path
+    .help = "A file containing a reference set of intensities e.g. MTZ/cif, or a"
+            "file from which a reference set of intensities can be calculated"
+            "e.g. .pdb or .cif . The space group of the reference file will"
+            "be used and if an indexing ambiguity is present, the input"
+            "data will be reindexed to be consistent with the indexing mode of"
+            "this reference file."
+    .expert_level = 2
 
 resolution
   .short_caption = "Resolution"
@@ -367,6 +378,8 @@ class MultiCrystalScale:
         self._reflections_filename = self._scaled._reflections_filename
 
         self.decide_space_group()
+
+        self.reindex()
 
         self._data_manager.export_unmerged_mtz(
             "scaled_unmerged.mtz", d_min=self._scaled.d_min
@@ -770,6 +783,31 @@ class MultiCrystalScale:
             logger.info(
                 "Laue group determined by dials.cosym: %s" % best_space_group.info()
             )
+
+    def reindex(self):
+        logger.debug("Running reindexing")
+        logger.info("Re-indexing to reference")
+        experiments_filename = self._data_manager.export_experiments("tmp.expt")
+        reflections_filename = self._data_manager.export_reflections("tmp.refl")
+        reindex = Reindex()
+        auto_logfiler(reindex)
+        reindex.set_experiments_filename(experiments_filename)
+        reindex.set_indexed_filename(reflections_filename)
+        reindex.set_reference_file(self._params.reference)
+
+        if self._params.symmetry.space_group is not None:
+            reindex.set_space_group(self._params.symmetry.space_group)
+
+        reindex.run()
+
+        self._experiments_filename = reindex.get_reindexed_experiments_filename()
+        self._reflections_filename = reindex.get_reindexed_reflections_filename()
+        self._data_manager.experiments = load.experiment_list(
+            self._experiments_filename, check_format=False
+        )
+        self._data_manager.reflections = flex.reflection_table.from_file(
+            self._reflections_filename
+        )
 
     def decide_space_group(self):
 

--- a/src/xia2/Wrappers/Dials/Reindex.py
+++ b/src/xia2/Wrappers/Dials/Reindex.py
@@ -22,6 +22,7 @@ def Reindex(DriverType=None):
             self._indexed_filename = None
             self._reference_filename = None
             self._reference_reflections = None
+            self._reference_file = None
             self._space_group = None
             self._cb_op = None
             self._hkl_offset = None
@@ -39,6 +40,9 @@ def Reindex(DriverType=None):
 
         def set_reference_reflections(self, reference_reflections):
             self._reference_reflections = reference_reflections
+
+        def set_reference_file(self, reference_file):
+            self._reference_file = reference_file
 
         def set_space_group(self, space_group):
             self._space_group = space_group
@@ -88,6 +92,8 @@ def Reindex(DriverType=None):
                 self.add_command_line(
                     "reference.reflections=%s" % self._reference_reflections
                 )
+            if self._reference_file is not None:
+                self.add_command_line("reference.file=%s" % self._reference_file)
             if self._cb_op:
                 self.add_command_line("change_of_basis_op=%s" % self._cb_op)
             if self._space_group:


### PR DESCRIPTION
Added in the functionality for multiplex to run dials.reindex based on a reference file. After many tests and discussions it seemed to work better comparing to the reference PDB at this stage rather than at the initial cosym stage. Also edited the xia2 reindex wrapper for dials after the functionality for having a reference file (ie PDB) was added. 