### PR TITLE
Change ssx ellipsoid model to use simple6 parameterisation

### DIFF
--- a/newsfragments/752.misc
+++ b/newsfragments/752.misc
@@ -1,0 +1,1 @@
+``xia2.ssx``: Change default ellipsoid integration model to simple6 parameterisation 

--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,1 +1,0 @@
-``xia2.ssx``: Fix error in progress reporting when no hits found or when no images indexed in a batch

--- a/src/xia2/Modules/SSX/xia2_ssx.py
+++ b/src/xia2/Modules/SSX/xia2_ssx.py
@@ -139,7 +139,7 @@ integration {
   algorithm = stills *ellipsoid
     .type = choice
     .expert_level=2
-  ellipsoid.rlp_mosaicity = *angular4 angular2 simple1 simple6
+  ellipsoid.rlp_mosaicity = angular4 angular2 simple1 *simple6
     .type = choice
     .expert_level=3
   phil = None


### PR DESCRIPTION
Change default as the angular2, angular4 models do not have a true angular dependence (sigma proportional to r) and are being replaced with updated models. Simple6 is a suitable default to capture anisotropy,. Practically, it is not clear that angular dependent mosaicity is a common effect in experimental data.