### PR TITLE
Cosym tolerance tailoring

### DIFF
--- a/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
@@ -127,7 +127,10 @@ symmetry
     .short_caption = "Resolve indexing ambiguity"
   cosym {
     include scope dials.algorithms.symmetry.cosym.phil_scope
-    include scope dials.command_line.cosym.phil_scope
+    relative_length_tolerance = 0.05
+      .type = float(value_min=0)
+    absolute_angle_tolerance = 2
+      .type = float(value_min=0)
   }
   laue_group = None
     .type = space_group

--- a/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
@@ -127,11 +127,7 @@ symmetry
     .short_caption = "Resolve indexing ambiguity"
   cosym {
     include scope dials.algorithms.symmetry.cosym.phil_scope
-    relative_length_tolerance = 0.05
-      .type = float(value_min=0)
-
-    absolute_angle_tolerance = 2
-      .type = float(value_min=0)
+    include scope dials.command_line.cosym.phil_scope
   }
   laue_group = None
     .type = space_group

--- a/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
@@ -127,6 +127,11 @@ symmetry
     .short_caption = "Resolve indexing ambiguity"
   cosym {
     include scope dials.algorithms.symmetry.cosym.phil_scope
+    relative_length_tolerance = 0.05
+      .type = float(value_min=0)
+
+    absolute_angle_tolerance = 2
+      .type = float(value_min=0)
   }
   laue_group = None
     .type = space_group
@@ -882,6 +887,12 @@ class MultiCrystalScale:
             cosym.set_space_group(self._params.symmetry.space_group.group())
         if self._params.symmetry.laue_group is not None:
             cosym.set_space_group(self._params.symmetry.laue_group.group())
+        cosym.set_relative_length_tolerance(
+            self._params.symmetry.cosym.relative_length_tolerance
+        )
+        cosym.set_absolute_angle_tolerance(
+            self._params.symmetry.cosym.absolute_angle_tolerance
+        )
         cosym.set_best_monoclinic_beta(self._params.symmetry.cosym.best_monoclinic_beta)
         cosym.set_lattice_symmetry_max_delta(
             self._params.symmetry.cosym.lattice_symmetry_max_delta

--- a/src/xia2/Wrappers/Dials/Cosym.py
+++ b/src/xia2/Wrappers/Dials/Cosym.py
@@ -37,6 +37,8 @@ def DialsCosym(DriverType=None, decay_correction=None):
             self._html = None
             self._best_monoclinic_beta = False
             self._lattice_symmetry_max_delta = None
+            self._relative_length_tolerance = None
+            self._absolute_angle_tolerance = None
 
         # getter and setter methods
 
@@ -66,6 +68,12 @@ def DialsCosym(DriverType=None, decay_correction=None):
 
         def set_lattice_symmetry_max_delta(self, lattice_symmetry_max_delta):
             self._lattice_symmetry_max_delta = lattice_symmetry_max_delta
+
+        def set_relative_length_tolerance(self, relative_length_tolerance):
+            self._relative_length_tolerance = relative_length_tolerance
+
+        def set_absolute_angle_tolerance(self, absolute_angle_tolerance):
+            self._absolute_angle_tolerance = absolute_angle_tolerance
 
         def get_json(self):
             return self._json
@@ -100,6 +108,15 @@ def DialsCosym(DriverType=None, decay_correction=None):
             if self._space_group is not None:
                 self.add_command_line(
                     "space_group=%s" % self._space_group.type().lookup_symbol()
+                )
+            if self._relative_length_tolerance is not None:
+                self.add_command_line(
+                    "relative_length_tolerance=%s" % self._relative_length_tolerance
+                )
+
+            if self._absolute_angle_tolerance is not None:
+                self.add_command_line(
+                    "absolute_angle_tolerance=%s" % self._absolute_angle_tolerance
                 )
 
             if not self._json:


### PR DESCRIPTION
Some auto-processed multi-crystal VMXi data from a user which was accessed through ispyb (processed with dials3.17) displayed very different multiplex clustering compared to current dials. It showed two distinct clusters in the correlation clustering on dials3.17, whereas current dials only produced one main cluster. After some investigating, it was found that the tightened tolerances in cosym rejected the data sets from this second cluster as being too different in the unit cell. We were able to manually process these clusters individually, and our user reported that after refinement the two clusters showed interesting structural differences. Therefore, we envision some use cases in multiplex where we may want to loosen these tolerances for more automated processing of clusters. These parameters `relative_length_tolerance` and `absolute_angle_tolerance` have been made accessible through multiplex in this PR without changing the default behaviour. 