### PR TITLE
Explicitly set a high d_min to avoid low estimate from resolutionizer in test

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Update test to fix regression test failures

--- a/tests/regression/test_cluster_analysis.py
+++ b/tests/regression/test_cluster_analysis.py
@@ -122,6 +122,7 @@ def test_serial_data(
         f"clustering.output_clusters={output_clusters}",
         f"output_correlation_cluster_number={output_correlation_cluster_number}",
         f"exclude_correlation_cluster_number={exclude_correlation_cluster_number}",
+        "d_min=1.0",
     ]
     result_generate_scaled = subprocess.run(
         args_generate_scaled, cwd=tmp_path, capture_output=True


### PR DESCRIPTION
Was causing regression test failures after dials change https://github.com/dials/dials/pull/2818