### PR TITLE
Fix crash in xia2.multiplex report generation if run with resolve_indexing_ambiguity=False

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``xia2.multiplex``: Fix crash in report generation if run with resolve_indexing_ambiguity=False

--- a/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
+++ b/src/xia2/Modules/MultiCrystal/ScaleAndMerge.py
@@ -396,6 +396,7 @@ class MultiCrystalScale:
         self._individual_report_dicts: dict[str, dict[str, Any]] = OrderedDict()
         self._comparison_graphs: dict[str, dict[str, Any]] = OrderedDict()
         self.scale_and_filter_results: scale_and_filter.AnalysisResults | None = None
+        self._cosym_analysis: dict[str, Any] = OrderedDict({"cosym_graphs": {}})
 
     def run(self) -> None:
         logger.notice(banner("Unit cell clustering"))  # type: ignore
@@ -1049,7 +1050,7 @@ class MultiCrystalScale:
             self._params.symmetry.cosym.lattice_symmetry_max_delta
         )
         cosym.run()
-        self._cosym_analysis: dict[str, Any] = cosym.get_cosym_analysis()
+        self._cosym_analysis = cosym.get_cosym_analysis()
         self._experiments_filename = cosym.get_reindexed_experiments()
         self._reflections_filename = cosym.get_reindexed_reflections()
         self._data_manager.experiments = load.experiment_list(


### PR DESCRIPTION
Currently using `resolve_indexing_ambiguity=False` leads to a traceback in the report generation ending in `AttributeError: 'MultiCrystalScale' object has no attribute '_cosym_analysis'`

Looks to have been broken for a long time, so I guess nobody uses this option.