### PR TITLE
xia2.ssx: remove unused, filtered reflections from dials data files by default.

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+``xia2.ssx_reduce``: Reduce processing filesize and memory usage by removing filtered reflections.

--- a/src/xia2/Modules/SSX/data_reduction_definitions.py
+++ b/src/xia2/Modules/SSX/data_reduction_definitions.py
@@ -72,6 +72,7 @@ class ReductionParams:
     reference_bsol: float = 46.0
     partiality_threshold: float = 0.25
     mean_i_over_sigma_threshold: float | None = None
+    remove_filtered_reflections: bool = True
 
     @classmethod
     def from_phil(cls, params: iotbx.phil.scope_extract):
@@ -136,4 +137,5 @@ class ReductionParams:
             params.reference_model.b_sol,
             params.partiality_threshold,
             params.filtering.mean_i_over_sigma_threshold,
+            params.filtering.remove_filtered_reflections,
         )

--- a/src/xia2/Modules/SSX/data_reduction_programs.py
+++ b/src/xia2/Modules/SSX/data_reduction_programs.py
@@ -627,7 +627,9 @@ def scale_against_reference(
         # Setup scaling
         # expts = load.experiment_list(files.expt, check_format=False)
         # table = flex.reflection_table.from_file(files.refl)
-        expts, table = combined_files_for_batch(batch)
+        expts, table = combined_files_for_batch(
+            batch, reduction_params.partiality_threshold
+        )
         params, diff_phil = _extract_scaling_params_for_scale_against_reference(
             reduction_params, name
         )
@@ -736,6 +738,19 @@ def scale_on_batches(
                         expts.select_on_experiment_identifiers(list(ids))
                         table = table.select_on_experiment_identifiers(list(ids))
                         table.reset_ids()
+                    # Do some filtering to reduce the table size (typically by over half)
+                    sel = table.get_flags(table.flags.integrated_sum)
+                    if "partiality" in table:
+                        sel &= (
+                            table["partiality"] > reduction_params.partiality_threshold
+                        )
+                    table = table.select(sel)
+                    if len(set(table["id"])) != len(ids):
+                        table.clean_experiment_identifiers_map()
+                        table.reset_ids()
+                        expts.select_on_experiment_identifiers(
+                            list(table.experiment_identifiers().values())
+                        )
                 all_expts.extend(expts)
                 tables.append(table)
         expts = all_expts
@@ -835,7 +850,7 @@ def _extract_cosym_params(reduction_params, index):
     return cosym_params, diff_phil
 
 
-def combined_files_for_batch(batch):
+def combined_files_for_batch(batch, partiality_threshold=0.25):
     all_expts = ExperimentList([])
     tables = []
     for fp in batch.filepairs:
@@ -847,6 +862,17 @@ def combined_files_for_batch(batch):
                 expts.select_on_experiment_identifiers(list(ids))
                 table = table.select_on_experiment_identifiers(list(ids))
                 table.reset_ids()
+            # Do some filtering to reduce the table size (typically by over half)
+            sel = table.get_flags(table.flags.integrated_sum)
+            if "partiality" in table:
+                sel &= table["partiality"] > partiality_threshold
+            table = table.select(sel)
+            if len(set(table["id"])) != len(ids):
+                table.clean_experiment_identifiers_map()
+                table.reset_ids()
+                expts.select_on_experiment_identifiers(
+                    list(table.experiment_identifiers().values())
+                )
         all_expts.extend(expts)
         tables.append(table)
     if len(tables) > 1:
@@ -881,7 +907,9 @@ def individual_cosym(
         )
         # cosym_params.cc_star_threshold = 0.1
         # cosym_params.angular_separation_threshold = 5
-        expts, table = combined_files_for_batch(batch)
+        expts, table = combined_files_for_batch(
+            batch, reduction_params.partiality_threshold
+        )
 
         tables = table.split_by_experiment_id()
         # now run cosym

--- a/src/xia2/Modules/SSX/data_reduction_programs.py
+++ b/src/xia2/Modules/SSX/data_reduction_programs.py
@@ -628,7 +628,9 @@ def scale_against_reference(
         # expts = load.experiment_list(files.expt, check_format=False)
         # table = flex.reflection_table.from_file(files.refl)
         expts, table = combined_files_for_batch(
-            batch, reduction_params.partiality_threshold
+            batch,
+            reduction_params.remove_filtered_reflections,
+            reduction_params.partiality_threshold,
         )
         params, diff_phil = _extract_scaling_params_for_scale_against_reference(
             reduction_params, name
@@ -739,18 +741,22 @@ def scale_on_batches(
                         table = table.select_on_experiment_identifiers(list(ids))
                         table.reset_ids()
                     # Do some filtering to reduce the table size (typically by over half)
-                    sel = table.get_flags(table.flags.integrated_sum)
-                    if "partiality" in table:
-                        sel &= (
-                            table["partiality"] > reduction_params.partiality_threshold
-                        )
-                    table = table.select(sel)
-                    if len(set(table["id"])) != len(ids):
-                        table.clean_experiment_identifiers_map()
-                        table.reset_ids()
-                        expts.select_on_experiment_identifiers(
-                            list(table.experiment_identifiers().values())
-                        )
+                    if reduction_params.remove_filtered_reflections:
+                        sel = table.get_flags(table.flags.integrated_sum)
+                        if (
+                            "partiality" in table
+                        ):  # Not the case for stills (not ellipsoid) integration algorithm
+                            sel &= (
+                                table["partiality"]
+                                > reduction_params.partiality_threshold
+                            )
+                        table = table.select(sel)
+                        if len(set(table["id"])) != len(ids):
+                            table.clean_experiment_identifiers_map()
+                            table.reset_ids()
+                            expts.select_on_experiment_identifiers(
+                                list(table.experiment_identifiers().values())
+                            )
                 all_expts.extend(expts)
                 tables.append(table)
         expts = all_expts
@@ -850,7 +856,9 @@ def _extract_cosym_params(reduction_params, index):
     return cosym_params, diff_phil
 
 
-def combined_files_for_batch(batch, partiality_threshold=0.25):
+def combined_files_for_batch(
+    batch, remove_filtered_reflections, partiality_threshold=0.25
+):
     all_expts = ExperimentList([])
     tables = []
     for fp in batch.filepairs:
@@ -863,16 +871,19 @@ def combined_files_for_batch(batch, partiality_threshold=0.25):
                 table = table.select_on_experiment_identifiers(list(ids))
                 table.reset_ids()
             # Do some filtering to reduce the table size (typically by over half)
-            sel = table.get_flags(table.flags.integrated_sum)
-            if "partiality" in table:
-                sel &= table["partiality"] > partiality_threshold
-            table = table.select(sel)
-            if len(set(table["id"])) != len(ids):
-                table.clean_experiment_identifiers_map()
-                table.reset_ids()
-                expts.select_on_experiment_identifiers(
-                    list(table.experiment_identifiers().values())
-                )
+            if remove_filtered_reflections:
+                sel = table.get_flags(table.flags.integrated_sum)
+                if (
+                    "partiality" in table
+                ):  # Not the case for stills (not ellipsoid) integration algorithm
+                    sel &= table["partiality"] > partiality_threshold
+                table = table.select(sel)
+                if len(set(table["id"])) != len(ids):
+                    table.clean_experiment_identifiers_map()
+                    table.reset_ids()
+                    expts.select_on_experiment_identifiers(
+                        list(table.experiment_identifiers().values())
+                    )
         all_expts.extend(expts)
         tables.append(table)
     if len(tables) > 1:
@@ -908,7 +919,9 @@ def individual_cosym(
         # cosym_params.cc_star_threshold = 0.1
         # cosym_params.angular_separation_threshold = 5
         expts, table = combined_files_for_batch(
-            batch, reduction_params.partiality_threshold
+            batch,
+            reduction_params.remove_filtered_reflections,
+            reduction_params.partiality_threshold,
         )
 
         tables = table.split_by_experiment_id()

--- a/src/xia2/Modules/SSX/xia2_ssx_reduce.py
+++ b/src/xia2/Modules/SSX/xia2_ssx_reduce.py
@@ -123,6 +123,15 @@ filtering {
     .type = float(allow_none=True)
     .help = "Apply a per-image mean I/sigma filter, calculated on reflections with"
             "partialities above the partiality_threshold."
+  remove_filtered_reflections = True
+    .type = bool
+    .help = "In the output DIALS reflection files, remove reflections that we not"
+            "successfully integrated, or that had partiality values below the"
+            "partiality threshold, which don't contribute to the final merged data."
+            "The actual filtering is controlled by the separate partiality_threshold"
+            "parameter. If False, these reflections are retained in the output files"
+            "even though they don't contribute to the final merged data, which may"
+            "be useful for debugging or further analysis."
 }
 symmetry {
   space_group = None


### PR DESCRIPTION
These are not used as part of the processing or result, so removing them reduces the memory pressure and overall size of processed output on disk.

Add an option, `remove_filtered_reflections` (default True), to enable these reflections to be retained in the output dials data files in case they are wanted for further analysis/debugging.
