### PR TITLE
Improve multiplex memory usage during cluster analysis

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+``xia2.multiplex``: Improvements to memory usage during cluster analysis


### PR DESCRIPTION
Remove two unnecessary copies of the reflection data in the multi-crystal-analysis class. Looks to be leftovers from before restructuring of the analysis classes. Likely improves peak memory usage by ~25%.